### PR TITLE
feat: add support for formatting beancount files

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,8 +1,11 @@
 package beancount
 
 import (
+	"os"
+
 	"github.com/alecthomas/kong"
 	"github.com/alecthomas/repr"
+	"github.com/robinvdvleuten/beancount/formatter"
 	"github.com/robinvdvleuten/beancount/parser"
 )
 
@@ -21,6 +24,42 @@ func (cmd *CheckCmd) Run(ctx *kong.Context) error {
 	return nil
 }
 
+type FormatCmd struct {
+	File           []byte `help:"Beancount input filename." arg:"" type:"filecontent"`
+	CurrencyColumn int    `help:"Column for currency alignment (overrides prefix-width and num-width if set, auto if 0)." default:"0"`
+	PrefixWidth    int    `help:"Width in characters for account names (auto if 0)." default:"0"`
+	NumWidth       int    `help:"Width for numbers (auto if 0)." default:"0"`
+}
+
+func (cmd *FormatCmd) Run(ctx *kong.Context) error {
+	// Parse the input file
+	ast, err := parser.ParseBytes(cmd.File)
+	if err != nil {
+		return err
+	}
+
+	// Create formatter with options
+	var opts []formatter.Option
+	if cmd.CurrencyColumn > 0 {
+		opts = append(opts, formatter.WithCurrencyColumn(cmd.CurrencyColumn))
+	}
+	if cmd.PrefixWidth > 0 {
+		opts = append(opts, formatter.WithPrefixWidth(cmd.PrefixWidth))
+	}
+	if cmd.NumWidth > 0 {
+		opts = append(opts, formatter.WithNumWidth(cmd.NumWidth))
+	}
+	f := formatter.New(opts...)
+
+	// Format and output to stdout
+	if err := f.Format(ast, cmd.File, os.Stdout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type Commands struct {
-	Check CheckCmd `cmd:"" help:"Parse, check and realize a beancount input file."`
+	Check  CheckCmd  `cmd:"" help:"Parse, check and realize a beancount input file."`
+	Format FormatCmd `cmd:"" help:"Format a beancount file to align numbers and currencies."`
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,116 @@
+package beancount
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/formatter"
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+func TestFormatCmd(t *testing.T) {
+	t.Run("BasicFormatting", func(t *testing.T) {
+		source := `
+option "title" "Test"
+
+2021-01-01 open Assets:Checking
+
+2021-01-02 * "Test transaction"
+  Assets:Checking  -100.00 USD
+  Expenses:Food  100.00 USD
+`
+		// Parse the input
+		ast, err := parser.ParseBytes([]byte(source))
+		assert.NoError(t, err)
+
+		// Format to buffer
+		f := formatter.New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// Verify output contains key elements
+		assert.True(t, bytes.Contains([]byte(output), []byte("option \"title\" \"Test\"")))
+		assert.True(t, bytes.Contains([]byte(output), []byte("2021-01-01 open Assets:Checking")))
+		assert.True(t, bytes.Contains([]byte(output), []byte("Assets:Checking")))
+		assert.True(t, bytes.Contains([]byte(output), []byte("100.00 USD")))
+	})
+
+	t.Run("WithCustomCurrencyColumn", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test"
+  Assets:Checking  -50.00 USD
+  Expenses:Food  50.00 USD
+`
+		// Parse the input
+		ast, err := parser.ParseBytes([]byte(source))
+		assert.NoError(t, err)
+
+		// Format with custom column
+		f := formatter.New(formatter.WithCurrencyColumn(60))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// Verify formatting occurred
+		assert.True(t, bytes.Contains([]byte(output), []byte("USD")))
+		// Verify custom column was used
+		assert.Equal(t, 60, f.CurrencyColumn)
+	})
+
+	t.Run("EmptyFile", func(t *testing.T) {
+		source := ``
+		// Empty file should parse successfully but produce no output
+		ast, err := parser.ParseBytes([]byte(source))
+		assert.NoError(t, err)
+
+		f := formatter.New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Empty file produces minimal output
+		output := buf.String()
+		_ = output
+	})
+}
+
+// TestFormatCmdIntegration tests the full command integration
+func TestFormatCmdIntegration(t *testing.T) {
+	t.Run("CompleteFile", func(t *testing.T) {
+		source := `
+option "title" "Integration Test"
+
+2021-01-01 commodity USD
+
+2021-01-01 open Assets:Checking  USD
+
+2021-01-02 * "Opening balance"
+  Assets:Checking  1000.00 USD
+  Equity:Opening-Balances  -1000.00 USD
+
+2021-01-03 balance Assets:Checking  1000.00 USD
+`
+		ast, err := parser.ParseBytes([]byte(source))
+		assert.NoError(t, err)
+
+		f := formatter.New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+
+		// Verify all directive types are present
+		assert.True(t, bytes.Contains([]byte(output), []byte("option")))
+		assert.True(t, bytes.Contains([]byte(output), []byte("commodity")))
+		assert.True(t, bytes.Contains([]byte(output), []byte("open")))
+		assert.True(t, bytes.Contains([]byte(output), []byte("balance")))
+
+		// Verify amounts are aligned
+		assert.True(t, bytes.Contains([]byte(output), []byte("1000.00 USD")))
+	})
+}

--- a/formatter/comments_test.go
+++ b/formatter/comments_test.go
@@ -1,0 +1,250 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+func TestCommentPreservation(t *testing.T) {
+	t.Run("StandaloneComments", func(t *testing.T) {
+		source := `; This is a header comment
+option "title" "Test"
+
+; Comment before directive
+2021-01-01 open Assets:Checking
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Verify comments are preserved
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; This is a header comment")),
+			"Header comment should be preserved")
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Comment before directive")),
+			"Comment before directive should be preserved")
+	})
+
+	t.Run("BlankLinePreservation", func(t *testing.T) {
+		source := `option "title" "Test"
+
+2021-01-01 open Assets:Checking
+
+2021-01-02 open Assets:Savings
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// Count newlines - should have blank lines preserved
+		lines := bytes.Split(buf.Bytes(), []byte("\n"))
+		hasBlankLines := false
+		for i := 0; i < len(lines)-1; i++ {
+			if len(bytes.TrimSpace(lines[i])) > 0 && len(bytes.TrimSpace(lines[i+1])) == 0 {
+				hasBlankLines = true
+				break
+			}
+		}
+		assert.True(t, hasBlankLines, "Blank lines should be preserved, got: %s", output)
+	})
+
+	t.Run("SectionComments", func(t *testing.T) {
+		source := `; Opening accounts
+
+2021-01-01 open Assets:Checking
+
+; Transactions
+
+2021-01-02 * "Test"
+  Assets:Checking  100.00 USD
+  Equity:Opening-Balances  -100.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Opening accounts")),
+			"Section comment should be preserved")
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Transactions")),
+			"Section comment should be preserved")
+	})
+
+	t.Run("DisableCommentPreservation", func(t *testing.T) {
+		source := `; This comment should not appear
+option "title" "Test"
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New(WithPreserveComments(false))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Comment should not be in output
+		assert.False(t, bytes.Contains(buf.Bytes(), []byte("; This comment should not appear")),
+			"Comment should not be preserved when disabled")
+	})
+
+	t.Run("DisableBlankPreservation", func(t *testing.T) {
+		source := `option "title" "Test"
+
+2021-01-01 open Assets:Checking
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New(WithPreserveBlanks(false))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have minimal blank lines
+		output := buf.String()
+		lines := bytes.Split(buf.Bytes(), []byte("\n"))
+		consecutiveBlanks := 0
+		for _, line := range lines {
+			if len(bytes.TrimSpace(line)) == 0 {
+				consecutiveBlanks++
+			} else {
+				consecutiveBlanks = 0
+			}
+		}
+		// With blank preservation disabled, shouldn't have consecutive blanks
+		assert.True(t, consecutiveBlanks <= 1, "Should not have multiple consecutive blanks, got: %s", output)
+	})
+
+	t.Run("MultipleComments", func(t *testing.T) {
+		source := `; Comment 1
+; Comment 2
+; Comment 3
+option "title" "Test"
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// All comments should be preserved
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Comment 1")))
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Comment 2")))
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Comment 3")))
+	})
+}
+
+func TestExtractCommentsAndBlanks(t *testing.T) {
+	t.Run("ExtractComments", func(t *testing.T) {
+		source := []byte(`; Comment 1
+option "title" "Test"
+; Comment 2
+2021-01-01 open Assets:Checking
+`)
+		comments, _ := extractCommentsAndBlanks(source)
+
+		assert.Equal(t, 2, len(comments))
+		assert.Equal(t, "; Comment 1", comments[0].Content)
+		assert.Equal(t, 1, comments[0].Line)
+		assert.Equal(t, "; Comment 2", comments[1].Content)
+		assert.Equal(t, 3, comments[1].Line)
+	})
+
+	t.Run("ExtractBlanks", func(t *testing.T) {
+		// Note: no trailing newline to avoid counting it as a blank line
+		source := []byte("option \"title\" \"Test\"\n\n2021-01-01 open Assets:Checking\n\n2021-01-02 open Assets:Savings")
+		_, blanks := extractCommentsAndBlanks(source)
+
+		assert.Equal(t, 2, len(blanks))
+		assert.Equal(t, 2, blanks[0].Line)
+		assert.Equal(t, 4, blanks[1].Line)
+	})
+
+	t.Run("SectionCommentType", func(t *testing.T) {
+		source := []byte(`; Section header
+
+2021-01-01 open Assets:Checking
+`)
+		comments, _ := extractCommentsAndBlanks(source)
+
+		assert.Equal(t, 1, len(comments))
+		assert.Equal(t, SectionComment, comments[0].Type, "Comment followed by blank should be section comment")
+	})
+
+	t.Run("StandaloneCommentType", func(t *testing.T) {
+		source := []byte(`; Regular comment
+2021-01-01 open Assets:Checking
+`)
+		comments, _ := extractCommentsAndBlanks(source)
+
+		assert.Equal(t, 1, len(comments))
+		assert.Equal(t, StandaloneComment, comments[0].Type, "Comment not followed by blank should be standalone")
+	})
+
+	t.Run("HashLinePreservation", func(t *testing.T) {
+		source := []byte(`# Options
+
+option "title" "Test"
+
+# Accounts
+2021-01-01 open Assets:Checking
+`)
+		comments, _ := extractCommentsAndBlanks(source)
+
+		assert.Equal(t, 2, len(comments))
+		assert.Equal(t, "# Options", comments[0].Content)
+		assert.Equal(t, 1, comments[0].Line)
+		assert.Equal(t, "# Accounts", comments[1].Content)
+		assert.Equal(t, 5, comments[1].Line)
+	})
+}
+
+func TestHashLineFormatting(t *testing.T) {
+	t.Run("PreserveOrgModeHeaders", func(t *testing.T) {
+		source := `# Options
+
+option "operating_currency" "EUR"
+
+# Commodities
+
+2022-01-01 commodity EUR
+
+# Accounts
+
+2023-01-01 open Assets:Checking EUR
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Verify hash headers are preserved
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("# Options")))
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("# Commodities")))
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("# Accounts")))
+
+		// Verify directives are formatted
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("option \"operating_currency\" \"EUR\"")))
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("2022-01-01 commodity EUR")))
+		assert.True(t, bytes.Contains(buf.Bytes(), []byte("2023-01-01 open Assets:Checking EUR")))
+	})
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,810 @@
+package formatter
+
+import (
+	"cmp"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+const (
+	// DefaultCurrencyColumn is the default column position for currency alignment
+	// (matches bean-format behavior)
+	DefaultCurrencyColumn = 52
+
+	// DefaultIndentation is the default indentation for postings and metadata
+	DefaultIndentation = 2
+
+	// MinimumSpacing is the minimum number of spaces between account/number and currency
+	MinimumSpacing = 2
+
+	// DateWidth is the width of a formatted date (YYYY-MM-DD)
+	DateWidth = 10
+
+	// BalanceKeywordWidth is the width of the "balance" keyword (7 chars) + space
+	BalanceKeywordWidth = 8
+
+	// PriceKeywordWidth is the width of the "price" keyword (5 chars) + space
+	PriceKeywordWidth = 6
+)
+
+// CommentType represents the type of comment in a beancount file.
+type CommentType int
+
+const (
+	// StandaloneComment appears on its own line before a directive
+	StandaloneComment CommentType = iota
+	// InlineComment appears at the end of a directive or posting line
+	InlineComment
+	// SectionComment is a standalone comment followed by a blank line (section header)
+	SectionComment
+)
+
+// CommentBlock represents a comment in the source file.
+type CommentBlock struct {
+	Line    int         // Line number where comment appears (1-indexed)
+	Content string      // Comment text (including semicolon)
+	Type    CommentType // Type of comment
+}
+
+// BlankLine represents a blank line in the source file.
+type BlankLine struct {
+	Line int // Line number (1-indexed)
+}
+
+// LineContent represents content that can appear before a directive.
+type LineContent interface {
+	isLineContent()
+	lineNumber() int
+}
+
+func (c CommentBlock) isLineContent() {}
+func (c CommentBlock) lineNumber() int { return c.Line }
+func (b BlankLine) isLineContent()     {}
+func (b BlankLine) lineNumber() int    { return b.Line }
+
+// DirectiveWithComments wraps a directive with its associated comments and blank lines.
+type DirectiveWithComments struct {
+	PrecedingLines []LineContent // Comments/blanks that appear before this directive
+	InlineComment  string         // Comment at the end of the directive line (empty if none)
+}
+
+// escapeString escapes special characters in strings for Beancount format.
+// It escapes double quotes and backslashes.
+func escapeString(s string) string {
+	// Quick check if escaping is needed
+	needsEscape := false
+	for _, c := range s {
+		if c == '"' || c == '\\' {
+			needsEscape = true
+			break
+		}
+	}
+
+	if !needsEscape {
+		return s
+	}
+
+	// Use strings.Builder for efficient escaping
+	var buf strings.Builder
+	buf.Grow(len(s) + 10) // Add some extra capacity for escape sequences
+
+	for _, c := range s {
+		switch c {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		default:
+			buf.WriteRune(c)
+		}
+	}
+
+	return buf.String()
+}
+
+// Formatter handles formatting of Beancount files with proper alignment.
+type Formatter struct {
+	// CurrencyColumn is the target column for currency alignment.
+	// If set (non-zero), this overrides PrefixWidth and NumWidth.
+	// If 0, it will be calculated from PrefixWidth + NumWidth, or auto-calculated.
+	CurrencyColumn int
+
+	// PrefixWidth is the width in characters to render the account name to.
+	// If 0, a good value is selected automatically from the contents.
+	PrefixWidth int
+
+	// NumWidth is the width to render each number.
+	// If 0, a good value is selected automatically from the contents.
+	NumWidth int
+
+	// PreserveComments controls whether comments are preserved during formatting.
+	// Default: true
+	PreserveComments bool
+
+	// PreserveBlanks controls whether blank lines are preserved during formatting.
+	// Default: true
+	PreserveBlanks bool
+}
+
+// Option is a functional option for configuring a Formatter.
+type Option func(*Formatter)
+
+// WithCurrencyColumn sets a specific column for currency alignment.
+// This overrides PrefixWidth and NumWidth if set.
+func WithCurrencyColumn(col int) Option {
+	return func(f *Formatter) {
+		f.CurrencyColumn = col
+	}
+}
+
+// WithPrefixWidth sets the width in characters to render account names to.
+func WithPrefixWidth(width int) Option {
+	return func(f *Formatter) {
+		f.PrefixWidth = width
+	}
+}
+
+// WithNumWidth sets the width to render each number.
+func WithNumWidth(width int) Option {
+	return func(f *Formatter) {
+		f.NumWidth = width
+	}
+}
+
+// WithPreserveComments enables or disables comment preservation.
+func WithPreserveComments(preserve bool) Option {
+	return func(f *Formatter) {
+		f.PreserveComments = preserve
+	}
+}
+
+// WithPreserveBlanks enables or disables blank line preservation.
+func WithPreserveBlanks(preserve bool) Option {
+	return func(f *Formatter) {
+		f.PreserveBlanks = preserve
+	}
+}
+
+// New creates a new Formatter with the given options.
+func New(opts ...Option) *Formatter {
+	f := &Formatter{
+		CurrencyColumn:   0,    // 0 means auto-calculate
+		PreserveComments: true, // Preserve comments by default
+		PreserveBlanks:   true, // Preserve blank lines by default
+	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
+}
+
+// widthMetrics holds calculated width information for formatting.
+type widthMetrics struct {
+	maxPrefixWidth int // Maximum width of account prefix (indentation + flag + account + spacing)
+	maxNumWidth    int // Maximum width of numeric values
+	currencyColumn int // Calculated currency column position
+}
+
+// calculateWidthMetrics performs a single pass through the AST to calculate all width metrics.
+func (f *Formatter) calculateWidthMetrics(ast *parser.AST) widthMetrics {
+	metrics := widthMetrics{}
+
+	for _, directive := range ast.Directives {
+		switch d := directive.(type) {
+		case *parser.Transaction:
+			for _, posting := range d.Postings {
+				if posting.Amount != nil {
+					// Calculate prefix width: indentation + flag + account + spacing
+					prefixWidth := DefaultIndentation
+					if posting.Flag != "" {
+						prefixWidth += 2 // flag + space
+					}
+					prefixWidth += len(string(posting.Account)) + MinimumSpacing
+					metrics.maxPrefixWidth = max(metrics.maxPrefixWidth, prefixWidth)
+
+					// Calculate number width
+					numWidth := len(posting.Amount.Value)
+					metrics.maxNumWidth = max(metrics.maxNumWidth, numWidth)
+
+					// Calculate total width for currency column
+					totalWidth := prefixWidth + numWidth
+					metrics.currencyColumn = max(metrics.currencyColumn, totalWidth)
+				}
+			}
+
+		case *parser.Balance:
+			if d.Amount != nil {
+				// Calculate width: date + "balance" + account + spacing + number
+				width := DateWidth + 1 + BalanceKeywordWidth + len(string(d.Account)) + MinimumSpacing
+				numWidth := len(d.Amount.Value)
+				metrics.maxNumWidth = max(metrics.maxNumWidth, numWidth)
+				totalWidth := width + numWidth
+				metrics.currencyColumn = max(metrics.currencyColumn, totalWidth)
+			}
+
+		case *parser.Price:
+			if d.Amount != nil {
+				// Calculate width: date + "price" + commodity + spacing + number
+				width := DateWidth + 1 + PriceKeywordWidth + len(d.Commodity) + MinimumSpacing
+				numWidth := len(d.Amount.Value)
+				metrics.maxNumWidth = max(metrics.maxNumWidth, numWidth)
+				totalWidth := width + numWidth
+				metrics.currencyColumn = max(metrics.currencyColumn, totalWidth)
+			}
+		}
+	}
+
+	return metrics
+}
+
+// calculateCurrencyColumn auto-calculates the currency column from AST content.
+// Returns the default column if no amounts are found.
+func (f *Formatter) calculateCurrencyColumn(ast *parser.AST) int {
+	metrics := f.calculateWidthMetrics(ast)
+	if metrics.currencyColumn > 0 {
+		return metrics.currencyColumn + MinimumSpacing
+	}
+	return DefaultCurrencyColumn
+}
+
+// determineCurrencyColumn calculates the currency column based on configuration.
+// Priority: explicit widths (PrefixWidth/NumWidth) > auto-calculated from content > default.
+func (f *Formatter) determineCurrencyColumn(ast *parser.AST) int {
+	// If explicit widths are provided, use those
+	if f.PrefixWidth > 0 || f.NumWidth > 0 {
+		metrics := f.calculateWidthMetrics(ast)
+
+		prefixWidth := f.PrefixWidth
+		if prefixWidth == 0 {
+			prefixWidth = metrics.maxPrefixWidth
+			if prefixWidth == 0 {
+				prefixWidth = 40 // Default prefix width
+			}
+		}
+
+		numWidth := f.NumWidth
+		if numWidth == 0 {
+			numWidth = metrics.maxNumWidth + MinimumSpacing
+			if numWidth == MinimumSpacing {
+				numWidth = 10 // Default number width
+			}
+		}
+
+		return prefixWidth + numWidth
+	}
+
+	// Auto-calculate from content
+	return f.calculateCurrencyColumn(ast)
+}
+
+// Format formats the given AST and writes the output to the writer.
+// astItem represents any item in the AST with its position
+type astItem struct {
+	pos       int
+	option    *parser.Option
+	include   *parser.Include
+	directive parser.Directive
+}
+
+// Comments and blank lines from sourceContent are preserved based on Formatter configuration.
+func (f *Formatter) Format(ast *parser.AST, sourceContent []byte, w io.Writer) error {
+	// Determine the currency column based on the configuration
+	if f.CurrencyColumn == 0 {
+		f.CurrencyColumn = f.determineCurrencyColumn(ast)
+	}
+
+	// Extract comments and blank lines if preservation is enabled
+	var lineContentMap map[int][]LineContent
+	if f.PreserveComments || f.PreserveBlanks {
+		comments, blanks := extractCommentsAndBlanks(sourceContent)
+
+		// Filter based on configuration
+		if !f.PreserveComments {
+			comments = nil
+		}
+		if !f.PreserveBlanks {
+			blanks = nil
+		}
+
+		// Build a map of line numbers to content
+		lineContentMap = buildLineContentMap(comments, blanks)
+	}
+
+	// Use a string builder to buffer all output, then write once
+	var buf strings.Builder
+
+	// Estimate initial capacity to reduce allocations
+	estimatedSize := (len(ast.Options) + len(ast.Includes) + len(ast.Directives)) * 100
+	buf.Grow(estimatedSize)
+
+	// Collect all items (options, includes, directives) with their positions
+	var items []astItem
+
+	for _, opt := range ast.Options {
+		if opt != nil {
+			items = append(items, astItem{pos: opt.Pos.Line, option: opt})
+		}
+	}
+
+	for _, inc := range ast.Includes {
+		if inc != nil {
+			items = append(items, astItem{pos: inc.Pos.Line, include: inc})
+		}
+	}
+
+	for _, directive := range ast.Directives {
+		if directive != nil {
+			pos := getDirectivePos(directive)
+			items = append(items, astItem{pos: pos, directive: directive})
+		}
+	}
+
+	// Sort all items by their original position in the file
+	slices.SortFunc(items, func(a, b astItem) int {
+		return cmp.Compare(a.pos, b.pos)
+	})
+
+	// Track the last line we've processed
+	lastLine := 0
+
+	// Format all items in order
+	for _, item := range items {
+		if lineContentMap != nil {
+			f.outputPrecedingContent(item.pos, lastLine, lineContentMap, &buf)
+			lastLine = item.pos
+		}
+
+		if item.option != nil {
+			f.formatOption(item.option, &buf)
+		} else if item.include != nil {
+			f.formatInclude(item.include, &buf)
+		} else if item.directive != nil {
+			f.formatDirective(item.directive, &buf)
+		}
+	}
+
+	// Write all output at once
+	_, err := w.Write([]byte(buf.String()))
+	return err
+}
+
+// determineCommentType checks if a comment is a section header by looking at the next line.
+func determineCommentType(currentIndex int, lines []string) CommentType {
+	if currentIndex+1 < len(lines) && strings.TrimSpace(lines[currentIndex+1]) == "" {
+		return SectionComment
+	}
+	return StandaloneComment
+}
+
+// extractCommentsAndBlanks scans the source content and extracts all comments and blank lines.
+// Returns sorted slices of comments and blank lines by line number.
+func extractCommentsAndBlanks(sourceContent []byte) ([]CommentBlock, []BlankLine) {
+	var comments []CommentBlock
+	var blanks []BlankLine
+
+	lines := strings.Split(string(sourceContent), "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1 // 1-indexed line numbers
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			// Blank line
+			blanks = append(blanks, BlankLine{Line: lineNum})
+		} else if strings.HasPrefix(trimmed, ";") {
+			// Beancount comment line
+			comments = append(comments, CommentBlock{
+				Line:    lineNum,
+				Content: trimmed, // Store trimmed version
+				Type:    determineCommentType(i, lines),
+			})
+		} else if strings.HasPrefix(trimmed, "#") && !isBeancountDirectiveLine(trimmed) {
+			// Hash line (org-mode headers, markdown, etc.) - but not Beancount tags
+			// Tags like "#vacation" appear on directive lines, not standalone
+			comments = append(comments, CommentBlock{
+				Line:    lineNum,
+				Content: trimmed, // Store trimmed version
+				Type:    determineCommentType(i, lines),
+			})
+		}
+		// Note: Inline comments are handled separately during formatting
+		// as they require parsing the line structure
+	}
+
+	return comments, blanks
+}
+
+// isBeancountDirectiveLine checks if a line looks like it starts with a Beancount directive.
+// This helps distinguish between hash headers (# Options) and tag usage on directive lines.
+func isBeancountDirectiveLine(line string) bool {
+	// Beancount directives start with a date (YYYY-MM-DD) or keywords like "option", "include"
+	if len(line) >= 10 && line[4] == '-' && line[7] == '-' {
+		// Looks like a date at the start
+		return true
+	}
+	// Check for directive keywords
+	if strings.HasPrefix(line, "option ") || strings.HasPrefix(line, "include ") {
+		return true
+	}
+	return false
+}
+
+// buildLineContentMap creates a map from line numbers to the content (comments/blanks) on those lines.
+func buildLineContentMap(comments []CommentBlock, blanks []BlankLine) map[int][]LineContent {
+	lineMap := make(map[int][]LineContent)
+
+	for _, comment := range comments {
+		lineMap[comment.Line] = append(lineMap[comment.Line], comment)
+	}
+
+	for _, blank := range blanks {
+		lineMap[blank.Line] = append(lineMap[blank.Line], blank)
+	}
+
+	return lineMap
+}
+
+// getDirectivePos extracts the line position from any directive type.
+func getDirectivePos(d parser.Directive) int {
+	switch directive := d.(type) {
+	case *parser.Commodity:
+		return directive.Pos.Line
+	case *parser.Open:
+		return directive.Pos.Line
+	case *parser.Close:
+		return directive.Pos.Line
+	case *parser.Balance:
+		return directive.Pos.Line
+	case *parser.Pad:
+		return directive.Pos.Line
+	case *parser.Note:
+		return directive.Pos.Line
+	case *parser.Document:
+		return directive.Pos.Line
+	case *parser.Price:
+		return directive.Pos.Line
+	case *parser.Event:
+		return directive.Pos.Line
+	case *parser.Transaction:
+		return directive.Pos.Line
+	default:
+		return 0
+	}
+}
+
+// outputPrecedingContent outputs any comments or blank lines that appear between
+// lastLine and currentLine in the source file.
+func (f *Formatter) outputPrecedingContent(currentLine, lastLine int, lineContentMap map[int][]LineContent, buf *strings.Builder) {
+	// Output content for lines between lastLine and currentLine (exclusive)
+	for line := lastLine + 1; line < currentLine; line++ {
+		if content, exists := lineContentMap[line]; exists {
+			for _, item := range content {
+				switch c := item.(type) {
+				case CommentBlock:
+					buf.WriteString(c.Content)
+					buf.WriteByte('\n')
+				case BlankLine:
+					buf.WriteByte('\n')
+				}
+			}
+		}
+	}
+}
+
+// formatDirective formats a directive based on its type.
+func (f *Formatter) formatDirective(d parser.Directive, buf *strings.Builder) {
+	switch directive := d.(type) {
+	case *parser.Commodity:
+		f.formatCommodity(directive, buf)
+	case *parser.Open:
+		f.formatOpen(directive, buf)
+	case *parser.Close:
+		f.formatClose(directive, buf)
+	case *parser.Balance:
+		f.formatBalance(directive, buf)
+	case *parser.Pad:
+		f.formatPad(directive, buf)
+	case *parser.Note:
+		f.formatNote(directive, buf)
+	case *parser.Document:
+		f.formatDocument(directive, buf)
+	case *parser.Price:
+		f.formatPrice(directive, buf)
+	case *parser.Event:
+		f.formatEvent(directive, buf)
+	case *parser.Transaction:
+		f.formatTransaction(directive, buf)
+	}
+}
+
+// formatOption formats an option directive.
+func (f *Formatter) formatOption(opt *parser.Option, buf *strings.Builder) {
+	buf.WriteString("option \"")
+	buf.WriteString(escapeString(opt.Name))
+	buf.WriteString("\" \"")
+	buf.WriteString(escapeString(opt.Value))
+	buf.WriteString("\"\n")
+}
+
+// formatInclude formats an include directive.
+func (f *Formatter) formatInclude(inc *parser.Include, buf *strings.Builder) {
+	buf.WriteString("include \"")
+	buf.WriteString(escapeString(inc.Filename))
+	buf.WriteString("\"\n")
+}
+
+// formatCommodity formats a commodity directive.
+func (f *Formatter) formatCommodity(c *parser.Commodity, buf *strings.Builder) {
+	buf.WriteString(c.Date.Format("2006-01-02"))
+	buf.WriteString(" commodity ")
+	buf.WriteString(c.Currency)
+	buf.WriteByte('\n')
+	f.formatMetadata(c.Metadata, buf)
+}
+
+// formatOpen formats an open directive.
+func (f *Formatter) formatOpen(o *parser.Open, buf *strings.Builder) {
+	buf.WriteString(o.Date.Format("2006-01-02"))
+	buf.WriteString(" open ")
+	buf.WriteString(string(o.Account))
+
+	// Add constraint currencies if present, with minimal spacing (not aligned)
+	if len(o.ConstraintCurrencies) > 0 {
+		buf.WriteString(" ")
+		for i, currency := range o.ConstraintCurrencies {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(currency)
+		}
+	}
+
+	// Add booking method if present
+	if o.BookingMethod != "" {
+		buf.WriteString(" \"")
+		buf.WriteString(o.BookingMethod)
+		buf.WriteByte('"')
+	}
+
+	buf.WriteByte('\n')
+	f.formatMetadata(o.Metadata, buf)
+}
+
+// formatClose formats a close directive.
+func (f *Formatter) formatClose(c *parser.Close, buf *strings.Builder) {
+	buf.WriteString(c.Date.Format("2006-01-02"))
+	buf.WriteString(" close ")
+	buf.WriteString(string(c.Account))
+	buf.WriteByte('\n')
+	f.formatMetadata(c.Metadata, buf)
+}
+
+// formatBalance formats a balance directive.
+func (f *Formatter) formatBalance(b *parser.Balance, buf *strings.Builder) {
+	buf.WriteString(b.Date.Format("2006-01-02"))
+	buf.WriteString(" balance ")
+	buf.WriteString(string(b.Account))
+
+	if b.Amount != nil {
+		f.formatAmountAligned(b.Amount, buf.Len(), buf)
+	}
+
+	buf.WriteByte('\n')
+	f.formatMetadata(b.Metadata, buf)
+}
+
+// formatPad formats a pad directive.
+func (f *Formatter) formatPad(p *parser.Pad, buf *strings.Builder) {
+	buf.WriteString(p.Date.Format("2006-01-02"))
+	buf.WriteString(" pad ")
+	buf.WriteString(string(p.Account))
+	buf.WriteByte(' ')
+	buf.WriteString(string(p.AccountPad))
+	buf.WriteByte('\n')
+	f.formatMetadata(p.Metadata, buf)
+}
+
+// formatNote formats a note directive.
+func (f *Formatter) formatNote(n *parser.Note, buf *strings.Builder) {
+	buf.WriteString(n.Date.Format("2006-01-02"))
+	buf.WriteString(" note ")
+	buf.WriteString(string(n.Account))
+	buf.WriteString(" \"")
+	buf.WriteString(escapeString(n.Description))
+	buf.WriteString("\"\n")
+	f.formatMetadata(n.Metadata, buf)
+}
+
+// formatDocument formats a document directive.
+func (f *Formatter) formatDocument(d *parser.Document, buf *strings.Builder) {
+	buf.WriteString(d.Date.Format("2006-01-02"))
+	buf.WriteString(" document ")
+	buf.WriteString(string(d.Account))
+	buf.WriteString(" \"")
+	buf.WriteString(escapeString(d.PathToDocument))
+	buf.WriteString("\"\n")
+	f.formatMetadata(d.Metadata, buf)
+}
+
+// formatPrice formats a price directive.
+func (f *Formatter) formatPrice(p *parser.Price, buf *strings.Builder) {
+	buf.WriteString(p.Date.Format("2006-01-02"))
+	buf.WriteString(" price ")
+	buf.WriteString(p.Commodity)
+
+	if p.Amount != nil {
+		f.formatAmountAligned(p.Amount, buf.Len(), buf)
+	}
+
+	buf.WriteByte('\n')
+	f.formatMetadata(p.Metadata, buf)
+}
+
+// formatEvent formats an event directive.
+func (f *Formatter) formatEvent(e *parser.Event, buf *strings.Builder) {
+	buf.WriteString(e.Date.Format("2006-01-02"))
+	buf.WriteString(" event \"")
+	buf.WriteString(escapeString(e.Name))
+	buf.WriteString("\" \"")
+	buf.WriteString(escapeString(e.Value))
+	buf.WriteString("\"\n")
+	f.formatMetadata(e.Metadata, buf)
+}
+
+// formatTransaction formats a transaction directive with proper structure.
+// Format: date flag [payee] [narration] [links] [tags]
+// Note: Strings are re-quoted as the parser unquotes them during parsing.
+// The parser's lexer doesn't support escaped quotes within strings.
+func (f *Formatter) formatTransaction(t *parser.Transaction, buf *strings.Builder) {
+	// First line: date, flag, payee (optional), narration, tags, links
+	buf.WriteString(t.Date.Format("2006-01-02"))
+	buf.WriteByte(' ')
+	buf.WriteString(t.Flag)
+
+	// Add payee if present (always quoted)
+	if t.Payee != "" {
+		buf.WriteString(" \"")
+		buf.WriteString(escapeString(t.Payee))
+		buf.WriteByte('"')
+	}
+
+	// Add narration if present (always quoted)
+	if t.Narration != "" {
+		buf.WriteString(" \"")
+		buf.WriteString(escapeString(t.Narration))
+		buf.WriteByte('"')
+	}
+
+	// Add links (prefixed with ^)
+	for _, link := range t.Links {
+		buf.WriteString(" ^")
+		buf.WriteString(string(link))
+	}
+
+	// Add tags (prefixed with #)
+	for _, tag := range t.Tags {
+		buf.WriteString(" #")
+		buf.WriteString(string(tag))
+	}
+
+	buf.WriteByte('\n')
+
+	// Transaction-level metadata (indented with 2 spaces)
+	f.formatMetadata(t.Metadata, buf)
+
+	// Format each posting with proper alignment
+	for _, posting := range t.Postings {
+		f.formatPosting(posting, buf)
+	}
+}
+
+// formatPosting formats a single posting with proper alignment.
+// Handles both postings with explicit amounts and implied amounts (nil).
+func (f *Formatter) formatPosting(p *parser.Posting, buf *strings.Builder) {
+	buf.WriteString("  ")
+
+	// Add flag if present
+	if p.Flag != "" {
+		buf.WriteString(p.Flag)
+		buf.WriteByte(' ')
+	}
+
+	buf.WriteString(string(p.Account))
+
+	// Add amount if present (explicit amount)
+	// If amount is nil, this is an implied/calculated amount posting
+	if p.Amount != nil {
+		f.formatAmountAligned(p.Amount, buf.Len(), buf)
+
+		// Add cost specification if present (e.g., {150.00 USD})
+		if p.Cost != nil {
+			buf.WriteByte(' ')
+			f.formatCost(p.Cost, buf)
+		}
+
+		// Add price annotation if present (e.g., @ 1.50 EUR or @@ 150.00 EUR)
+		if p.Price != nil {
+			if p.PriceTotal {
+				buf.WriteString(" @@")
+			} else {
+				buf.WriteString(" @")
+			}
+			buf.WriteByte(' ')
+			buf.WriteString(p.Price.Value)
+			buf.WriteByte(' ')
+			buf.WriteString(p.Price.Currency)
+		}
+	}
+
+	buf.WriteByte('\n')
+
+	// Posting-level metadata (always format, even for implied amounts)
+	f.formatMetadata(p.Metadata, buf)
+}
+
+// formatAmountAligned formats an amount with proper alignment to the currency column.
+func (f *Formatter) formatAmountAligned(amount *parser.Amount, currentWidth int, buf *strings.Builder) {
+	if amount == nil {
+		return
+	}
+
+	// Calculate padding needed
+	padding := f.CurrencyColumn - currentWidth - len(amount.Value)
+	if padding < MinimumSpacing {
+		padding = MinimumSpacing
+	}
+
+	// Use strings.Repeat for efficient padding
+	buf.WriteString(strings.Repeat(" ", padding))
+	buf.WriteString(amount.Value)
+	buf.WriteByte(' ')
+	buf.WriteString(amount.Currency)
+}
+
+// formatCost formats a cost specification.
+func (f *Formatter) formatCost(cost *parser.Cost, buf *strings.Builder) {
+	if cost == nil {
+		return
+	}
+
+	buf.WriteByte('{')
+
+	if cost.Amount != nil {
+		buf.WriteString(cost.Amount.Value)
+		buf.WriteByte(' ')
+		buf.WriteString(cost.Amount.Currency)
+	}
+
+	if cost.Date != nil {
+		buf.WriteString(", ")
+		buf.WriteString(cost.Date.Format("2006-01-02"))
+	}
+
+	if cost.Label != "" {
+		buf.WriteString(", \"")
+		buf.WriteString(escapeString(cost.Label))
+		buf.WriteByte('"')
+	}
+
+	buf.WriteByte('}')
+}
+
+// formatMetadata formats metadata entries with proper indentation.
+func (f *Formatter) formatMetadata(metadata []*parser.Metadata, buf *strings.Builder) {
+	if len(metadata) == 0 {
+		return
+	}
+
+	for _, m := range metadata {
+		buf.WriteString("  ")
+		buf.WriteString(m.Key)
+		buf.WriteString(": \"")
+		buf.WriteString(m.Value)
+		buf.WriteString("\"\n")
+	}
+}

--- a/formatter/formatter_bench_test.go
+++ b/formatter/formatter_bench_test.go
@@ -1,0 +1,227 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+// BenchmarkFormat benchmarks the formatter with various file sizes
+func BenchmarkFormat(b *testing.B) {
+	b.Run("SmallFile", func(b *testing.B) {
+		source := `
+option "title" "Test Ledger"
+
+2021-01-01 open Assets:Checking USD
+2021-01-01 open Expenses:Food
+
+2021-01-02 * "Grocery Store" "Weekly groceries"
+  Assets:Checking  -75.50 USD
+  Expenses:Food  75.50 USD
+`
+		ast, err := parser.ParseString(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		f := New()
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := f.Format(ast, []byte(source), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("MediumFile", func(b *testing.B) {
+		// Generate a medium-sized ledger with multiple transactions
+		var source string
+		source += `option "title" "Test Ledger"
+option "operating_currency" "USD"
+
+2021-01-01 open Assets:Checking USD
+2021-01-01 open Assets:Savings USD
+2021-01-01 open Expenses:Food USD
+2021-01-01 open Expenses:Transportation USD
+2021-01-01 open Income:Salary USD
+
+`
+		// Add 100 transactions
+		for i := 1; i <= 100; i++ {
+			source += `2021-01-02 * "Store" "Purchase"
+  Assets:Checking  -50.00 USD
+  Expenses:Food  50.00 USD
+
+`
+		}
+
+		ast, err := parser.ParseString(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		f := New()
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := f.Format(ast, []byte(source), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("LargeFile", func(b *testing.B) {
+		// Generate a large ledger with many transactions
+		var source string
+		source += `option "title" "Large Test Ledger"
+
+2021-01-01 open Assets:US:BofA:Checking USD
+2021-01-01 open Expenses:Food:Restaurant USD
+
+`
+		// Add 1000 transactions
+		for i := 1; i <= 1000; i++ {
+			source += `2021-01-02 * "Restaurant Name" "Lunch meeting"
+  Assets:US:BofA:Checking  -125.75 USD
+  Expenses:Food:Restaurant  125.75 USD
+
+`
+		}
+
+		ast, err := parser.ParseString(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		f := New()
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := f.Format(ast, []byte(source), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkFormatWithComments benchmarks formatting files that contain comments
+func BenchmarkFormatWithComments(b *testing.B) {
+	b.Run("SmallFileWithComments", func(b *testing.B) {
+		source := `; Header comment
+option "title" "Test Ledger"
+
+; Account section
+2021-01-01 open Assets:Checking  USD
+2021-01-01 open Expenses:Food
+
+; Transactions
+2021-01-02 * "Grocery Store" "Weekly groceries"
+  Assets:Checking  -75.50 USD
+  Expenses:Food  75.50 USD
+`
+		ast, err := parser.ParseString(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		f := New()
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := f.Format(ast, []byte(source), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("DisabledCommentPreservation", func(b *testing.B) {
+		source := `; Header comment
+option "title" "Test Ledger"
+
+2021-01-01 open Assets:Checking  USD
+2021-01-02 * "Test"
+  Assets:Checking  -75.50 USD
+  Expenses:Food  75.50 USD
+`
+		ast, err := parser.ParseString(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		f := New(WithPreserveComments(false), WithPreserveBlanks(false))
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			if err := f.Format(ast, []byte(source), &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkCurrencyColumnCalculation benchmarks just the currency column calculation
+func BenchmarkCurrencyColumnCalculation(b *testing.B) {
+	var source string
+	for i := 1; i <= 100; i++ {
+		source += `2021-01-02 * "Test"
+  Assets:Checking  -100.00 USD
+  Expenses:Food  100.00 USD
+
+`
+	}
+
+	ast, err := parser.ParseString(source)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	f := New()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		f.calculateCurrencyColumn(ast)
+	}
+}
+
+// BenchmarkStringBuilderVsConcat demonstrates the performance difference
+// This is for documentation purposes to show the improvement
+func BenchmarkStringBuilderVsConcat(b *testing.B) {
+	b.Run("StringBuilder", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			for j := 0; j < 100; j++ {
+				buf.WriteString("test string ")
+				buf.WriteString("another string ")
+				buf.WriteByte('\n')
+			}
+			_ = buf.String()
+		}
+	})
+
+	b.Run("StringConcat", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			output := ""
+			for j := 0; j < 100; j++ {
+				output += "test string "
+				output += "another string "
+				output += "\n"
+			}
+			_ = output
+		}
+	})
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,840 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+func TestEscapeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "NoEscaping",
+			input:    "simple string",
+			expected: "simple string",
+		},
+		{
+			name:     "DoubleQuote",
+			input:    `string with "quotes"`,
+			expected: `string with \"quotes\"`,
+		},
+		{
+			name:     "Backslash",
+			input:    `path\to\file`,
+			expected: `path\\to\\file`,
+		},
+		{
+			name:     "Both",
+			input:    `path\with"both`,
+			expected: `path\\with\"both`,
+		},
+		{
+			name:     "Empty",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := escapeString(test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Run("DefaultOptions", func(t *testing.T) {
+		f := New()
+		assert.NotEqual(t, nil, f)
+		assert.Equal(t, 0, f.CurrencyColumn)
+	})
+
+	t.Run("WithCurrencyColumn", func(t *testing.T) {
+		f := New(WithCurrencyColumn(60))
+		assert.Equal(t, 60, f.CurrencyColumn)
+	})
+}
+
+func TestFormat(t *testing.T) {
+	t.Run("BasicFormat", func(t *testing.T) {
+		source := `
+2021-01-01 open Assets:Checking
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// For now, just verify no error - actual formatting will be implemented in later steps
+		// assert.True(t, buf.Len() > 0, "Should have written output")
+	})
+
+	t.Run("WithCustomCurrencyColumn", func(t *testing.T) {
+		source := `
+2021-01-01 open Assets:Checking
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New(WithCurrencyColumn(70))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 70, f.CurrencyColumn)
+	})
+
+	t.Run("AutoCalculateCurrencyColumn", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test"
+  Assets:Checking  100.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have calculated a currency column
+		assert.True(t, f.CurrencyColumn > 0, "Should have auto-calculated currency column")
+	})
+}
+
+func TestCalculateCurrencyColumn(t *testing.T) {
+	t.Run("EmptyAST", func(t *testing.T) {
+		ast := &parser.AST{}
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+		assert.Equal(t, 52, column, "Should return default column for empty AST")
+	})
+
+	t.Run("SinglePosting", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test"
+  Assets:Checking  100.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+
+		// Width calculation: 2 (indent) + 15 (Assets:Checking) + 2 (spacing) + 6 (100.00) + 2 (buffer) = 27
+		assert.True(t, column >= 27, "Column should be at least 27")
+	})
+
+	t.Run("MultiplePostingsWithDifferentLengths", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test"
+  Assets:Checking  100.00 USD
+  Expenses:Food:Restaurant  50.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+
+		// Should align to the longest: 2 + 24 (Expenses:Food:Restaurant) + 2 + 5 (50.00) + 2 = 35
+		assert.True(t, column >= 35, "Column should accommodate longest account name")
+	})
+
+	t.Run("WithFlaggedPosting", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test"
+  ! Assets:Checking  100.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+
+		// Width with flag: 2 + 2 (flag+space) + 15 + 2 + 6 + 2 = 29
+		assert.True(t, column >= 29, "Column should account for flag")
+	})
+
+	t.Run("WithBalanceDirective", func(t *testing.T) {
+		source := `
+2021-01-02 balance Assets:US:BofA:Checking  3793.56 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+
+		// Width: 11 (date) + 8 (balance) + 27 (account) + 2 + 7 (number) + 2 = 57
+		// But let's check what we actually get
+		assert.True(t, column >= 50, "Column should accommodate balance directive, got: %d", column)
+	})
+
+	t.Run("WithPriceDirective", func(t *testing.T) {
+		source := `
+2021-01-01 price VBMPX  170.30 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+
+		// Width: 11 (date) + 6 (price) + 5 (VBMPX) + 2 + 6 (number) + 2 = 32
+		assert.True(t, column >= 32, "Column should accommodate price directive")
+	})
+
+	t.Run("MixedDirectives", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test"
+  Assets:Checking  100.00 USD
+  
+2021-01-02 balance Assets:US:BofA:Checking  3793.56 USD
+2021-01-03 price VBMPX  170.30 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		column := f.calculateCurrencyColumn(ast)
+
+		// Should align to the longest (balance directive in this case)
+		assert.True(t, column >= 50, "Column should accommodate all directive types")
+	})
+}
+
+func TestFormatDirectives(t *testing.T) {
+	t.Run("Option", func(t *testing.T) {
+		source := `option "title" "My Ledger"`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "option \"title\" \"My Ledger\"\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Include", func(t *testing.T) {
+		source := `include "2024.beancount"`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "include \"2024.beancount\"\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Commodity", func(t *testing.T) {
+		source := `2021-01-01 commodity USD`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-01-01 commodity USD\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		source := `2021-01-01 open Assets:Checking`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-01-01 open Assets:Checking\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("OpenWithCurrencies", func(t *testing.T) {
+		source := `2021-01-01 open Assets:Checking  USD, EUR`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Currencies should have minimal spacing (2 spaces), not aligned
+		output := buf.String()
+		assert.Contains(t, output, "2021-01-01 open Assets:Checking")
+		assert.Contains(t, output, "USD, EUR")
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		source := `2021-12-31 close Assets:Checking`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-12-31 close Assets:Checking\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Balance", func(t *testing.T) {
+		source := `2021-01-02 balance Assets:Checking  100.00 USD`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have aligned amount
+		assert.True(t, len(buf.String()) > 0)
+		assert.Contains(t, buf.String(), "USD")
+	})
+
+	t.Run("Pad", func(t *testing.T) {
+		source := `2021-01-01 pad Assets:Checking Equity:Opening-Balances`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-01-01 pad Assets:Checking Equity:Opening-Balances\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Note", func(t *testing.T) {
+		source := `2021-01-01 note Assets:Checking "Initial balance"`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-01-01 note Assets:Checking \"Initial balance\"\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Document", func(t *testing.T) {
+		source := `2021-01-01 document Assets:Checking "/path/to/doc.pdf"`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-01-01 document Assets:Checking \"/path/to/doc.pdf\"\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Price", func(t *testing.T) {
+		source := `2021-01-01 price AAPL  150.00 USD`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have aligned amount
+		assert.True(t, len(buf.String()) > 0)
+		assert.Contains(t, buf.String(), "USD")
+	})
+
+	t.Run("Event", func(t *testing.T) {
+		source := `2021-01-01 event "location" "New York"`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		expected := "2021-01-01 event \"location\" \"New York\"\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Transaction", func(t *testing.T) {
+		source := `
+2021-01-01 * "Groceries"
+  Assets:Checking  -50.00 USD
+  Expenses:Food  50.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// Should contain transaction header
+		assert.Contains(t, buf.String(), "2021-01-01 * \"Groceries\"")
+		// Should contain postings
+		assert.Contains(t, buf.String(), "Assets:Checking")
+		assert.Contains(t, buf.String(), "Expenses:Food")
+		// Should contain amounts
+		assert.Contains(t, buf.String(), "-50.00 USD")
+		assert.Contains(t, buf.String(), "50.00 USD")
+		_ = output
+	})
+
+	t.Run("TransactionWithTags", func(t *testing.T) {
+		source := `
+2021-01-01 * "Groceries" #food #grocery
+  Assets:Checking  -50.00 USD
+  Expenses:Food  50.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should contain tags
+		assert.Contains(t, buf.String(), "#food")
+		assert.Contains(t, buf.String(), "#grocery")
+	})
+
+	t.Run("TransactionWithLinks", func(t *testing.T) {
+		source := `
+2021-01-01 * "Groceries" ^invoice-123
+  Assets:Checking  -50.00 USD
+  Expenses:Food  50.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should contain link
+		assert.Contains(t, buf.String(), "^invoice-123")
+	})
+
+	t.Run("TransactionWithMetadata", func(t *testing.T) {
+		source := `
+2021-01-01 * "Groceries"
+  category: "Essential"
+  Assets:Checking  -50.00 USD
+  Expenses:Food  50.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should contain metadata (with quotes)
+		assert.Contains(t, buf.String(), "category: \"Essential\"")
+	})
+
+	t.Run("TransactionWithCost", func(t *testing.T) {
+		source := `
+2021-01-01 * "Buy Stock"
+  Assets:Stocks  10 AAPL {150.00 USD}
+  Assets:Cash  -1500.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should contain cost
+		assert.Contains(t, buf.String(), "{150.00 USD}")
+	})
+
+	t.Run("TransactionWithPrice", func(t *testing.T) {
+		source := `
+2021-01-01 * "Convert Currency"
+  Assets:USD  -100.00 USD @ 0.85 EUR
+  Assets:EUR  85.00 EUR
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should contain price
+		assert.Contains(t, buf.String(), "@ 0.85 EUR")
+	})
+}
+
+// TestTransactionEdgeCases tests edge cases for transaction formatting
+func TestTransactionEdgeCases(t *testing.T) {
+	t.Run("EmptyPosting", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test with implied amount"
+  Assets:Checking  -50.00 USD
+  Expenses:Food
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// Should contain both postings
+		assert.Contains(t, buf.String(), "Assets:Checking")
+		assert.Contains(t, buf.String(), "Expenses:Food")
+		// Should have the amount on first posting
+		assert.Contains(t, buf.String(), "-50.00 USD")
+		// Second posting should be just account name (implied amount)
+		lines := bytes.Split(buf.Bytes(), []byte("\n"))
+		foundExpensesLine := false
+		for _, line := range lines {
+			if bytes.Contains(line, []byte("Expenses:Food")) {
+				foundExpensesLine = true
+				// Should not have USD on the Expenses:Food line
+				assert.NotContains(t, string(line), "USD")
+			}
+		}
+		assert.True(t, foundExpensesLine, "Should find Expenses:Food line")
+		_ = output
+	})
+
+	t.Run("LongAccountName", func(t *testing.T) {
+		source := `
+2021-01-01 * "Very long account name"
+  Assets:Investments:Brokerage:Retirement:Traditional-IRA:Vanguard  1000.00 USD
+  Assets:Checking  -1000.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should handle long account names gracefully
+		assert.Contains(t, buf.String(), "Assets:Investments:Brokerage:Retirement:Traditional-IRA:Vanguard")
+		// Should have minimum spacing even with long names
+		assert.Contains(t, buf.String(), "1000.00 USD")
+	})
+
+	t.Run("NegativeNumbersWithVaryingDecimals", func(t *testing.T) {
+		source := `
+2021-01-01 * "Different decimal places"
+  Assets:AccountA  -1.5 USD
+  Assets:AccountB  -100.00 USD
+  Expenses:Test  101.50 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// All amounts should be present and properly aligned
+		assert.Contains(t, buf.String(), "-1.5 USD")
+		assert.Contains(t, buf.String(), "-100.00 USD")
+		assert.Contains(t, buf.String(), "101.50 USD")
+	})
+
+	t.Run("PostingWithAllFeatures", func(t *testing.T) {
+		source := `
+2021-01-01 * "Complete posting test"
+  category: "test"
+  ! Assets:Stocks  10 AAPL {150.00 USD, 2020-12-01} @ 155.00 USD
+    broker: "Schwab"
+  Assets:Cash  -1550.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// Should have transaction metadata (with quotes)
+		assert.Contains(t, buf.String(), "category: \"test\"")
+		// Should have flagged posting
+		assert.Contains(t, buf.String(), "! Assets:Stocks")
+		// Should have cost with date
+		assert.Contains(t, buf.String(), "{150.00 USD, 2020-12-01}")
+		// Should have price
+		assert.Contains(t, buf.String(), "@ 155.00 USD")
+		// Should have posting metadata (with quotes)
+		assert.Contains(t, buf.String(), "broker: \"Schwab\"")
+		_ = output
+	})
+
+	t.Run("MultiCurrencyTransaction", func(t *testing.T) {
+		source := `
+2021-01-01 * "Multi-currency"
+  Assets:USD  -100.00 USD
+  Assets:EUR  85.00 EUR
+  Assets:GBP  73.50 GBP
+  Equity:Conversions
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// All currencies should be present and aligned
+		assert.Contains(t, buf.String(), "USD")
+		assert.Contains(t, buf.String(), "EUR")
+		assert.Contains(t, buf.String(), "GBP")
+	})
+
+	t.Run("TransactionWithPayeeAndNarration", func(t *testing.T) {
+		source := `
+2021-01-01 * "Starbucks" "Morning coffee"
+  Assets:Checking  -5.50 USD
+  Expenses:Coffee  5.50 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have both payee and narration quoted
+		assert.Contains(t, buf.String(), "\"Starbucks\"")
+		assert.Contains(t, buf.String(), "\"Morning coffee\"")
+	})
+
+	t.Run("TransactionWithOnlyPayee", func(t *testing.T) {
+		source := `
+2021-01-01 * "Starbucks"
+  Assets:Checking  -5.50 USD
+  Expenses:Coffee  5.50 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		// When there's no second string, the first string is narration, not payee
+		// This is how beancount parser works
+		assert.Contains(t, buf.String(), "\"Starbucks\"")
+		_ = output
+	})
+
+	t.Run("ComplexCostSpecification", func(t *testing.T) {
+		source := `
+2021-01-01 * "Stock purchase with label"
+  Assets:Stocks  10 AAPL {150.00 USD, 2020-12-01, "lot-2020-q4"}
+  Assets:Cash  -1500.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have complete cost specification
+		assert.Contains(t, buf.String(), "{150.00 USD, 2020-12-01, \"lot-2020-q4\"}")
+	})
+
+	t.Run("TotalPriceAnnotation", func(t *testing.T) {
+		source := `
+2021-01-01 * "Total price test"
+  Assets:Stocks  10 AAPL @@ 1500.00 USD
+  Assets:Cash  -1500.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have @@ for total price
+		assert.Contains(t, buf.String(), "@@ 1500.00 USD")
+	})
+
+	t.Run("PostingWithMetadataOnly", func(t *testing.T) {
+		source := `
+2021-01-01 * "Posting metadata test"
+  Assets:Checking  -50.00 USD
+    receipt: "RCP-123"
+  Expenses:Groceries  50.00 USD
+`
+		ast, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f := New()
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Should have posting-level metadata properly indented (with quotes)
+		assert.Contains(t, buf.String(), "receipt: \"RCP-123\"")
+	})
+}
+
+// TestFormattingIdempotency tests that formatting is idempotent
+func TestFormattingIdempotency(t *testing.T) {
+	t.Run("FormattingTwiceProducesSameResult", func(t *testing.T) {
+		source := `
+2021-01-01 * "Test transaction"
+  Assets:Checking  -100.00 USD
+  Expenses:Food  100.00 USD
+`
+		// First format
+		ast1, err := parser.ParseString(source)
+		assert.NoError(t, err)
+
+		f1 := New()
+		var buf1 bytes.Buffer
+		err = f1.Format(ast1, []byte(source), &buf1)
+		assert.NoError(t, err)
+
+		formatted1 := buf1.String()
+
+		// Second format (format the already formatted output)
+		ast2, err := parser.ParseString(formatted1)
+		assert.NoError(t, err)
+
+		f2 := New()
+		var buf2 bytes.Buffer
+		err = f2.Format(ast2, []byte(formatted1), &buf2)
+		assert.NoError(t, err)
+
+		formatted2 := buf2.String()
+
+		// Both should be identical
+		assert.Equal(t, formatted1, formatted2, "Formatting should be idempotent")
+	})
+}
+
+func TestFormatterWidthOptions(t *testing.T) {
+	source := `2021-01-01 * "Test"
+  Assets:Bank:Checking  100.00 USD
+  Income:Salary  -100.00 USD
+`
+
+	ast, err := parser.ParseString(source)
+	assert.NoError(t, err)
+
+	t.Run("WithCurrencyColumn", func(t *testing.T) {
+		// CurrencyColumn overrides other options
+		f := New(WithCurrencyColumn(60))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Currency should be at column 60
+		output := buf.String()
+		assert.Contains(t, output, "2021-01-01 * \"Test\"")
+		// The exact spacing will depend on the implementation
+	})
+
+	t.Run("WithPrefixWidth", func(t *testing.T) {
+		// Only set prefix width, num width auto-calculated
+		f := New(WithPrefixWidth(40))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, "Assets:Bank:Checking")
+		assert.Contains(t, output, "USD")
+	})
+
+	t.Run("WithNumWidth", func(t *testing.T) {
+		// Only set num width, prefix width auto-calculated
+		f := New(WithNumWidth(15))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, "Assets:Bank:Checking")
+		assert.Contains(t, output, "USD")
+	})
+
+	t.Run("WithPrefixAndNumWidth", func(t *testing.T) {
+		// Both prefix and num width set
+		f := New(WithPrefixWidth(40), WithNumWidth(12))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// Currency column should be 40 + 12 = 52
+		assert.Equal(t, 52, f.CurrencyColumn)
+
+		output := buf.String()
+		assert.Contains(t, output, "Assets:Bank:Checking")
+		assert.Contains(t, output, "USD")
+	})
+
+	t.Run("CurrencyColumnOverridesPrefixAndNumWidth", func(t *testing.T) {
+		// CurrencyColumn should override PrefixWidth and NumWidth
+		f := New(WithCurrencyColumn(70), WithPrefixWidth(40), WithNumWidth(12))
+		var buf bytes.Buffer
+		err = f.Format(ast, []byte(source), &buf)
+		assert.NoError(t, err)
+
+		// CurrencyColumn should be 70 (not 40 + 12 = 52)
+		assert.Equal(t, 70, f.CurrencyColumn)
+	})
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -54,6 +54,7 @@ type Directive interface {
 }
 
 type Commodity struct {
+	Pos      lexer.Position
 	Date     *Date  `parser:"@Date 'commodity'"`
 	Currency string `parser:"@Ident"`
 
@@ -66,6 +67,7 @@ func (c *Commodity) date() *Date       { return c.Date }
 func (c *Commodity) Directive() string { return "commodity" }
 
 type Open struct {
+	Pos                  lexer.Position
 	Date                 *Date    `parser:"@Date 'open'"`
 	Account              Account  `parser:"@Account"`
 	ConstraintCurrencies []string `parser:"(@Ident (',' @Ident)*)?"`
@@ -80,6 +82,7 @@ func (o *Open) date() *Date       { return o.Date }
 func (o *Open) Directive() string { return "open" }
 
 type Close struct {
+	Pos     lexer.Position
 	Date    *Date   `parser:"@Date 'close'"`
 	Account Account `parser:"@Account"`
 
@@ -92,6 +95,7 @@ func (c *Close) date() *Date       { return c.Date }
 func (c *Close) Directive() string { return "close" }
 
 type Balance struct {
+	Pos     lexer.Position
 	Date    *Date   `parser:"@Date 'balance'"`
 	Account Account `parser:"@Account"`
 	Amount  *Amount `parser:"@@"`
@@ -105,6 +109,7 @@ func (b *Balance) date() *Date       { return b.Date }
 func (b *Balance) Directive() string { return "balance" }
 
 type Pad struct {
+	Pos        lexer.Position
 	Date       *Date   `parser:"@Date 'pad'"`
 	Account    Account `parser:"@Account"`
 	AccountPad Account `parser:"@Account"`
@@ -118,6 +123,7 @@ func (p *Pad) date() *Date       { return p.Date }
 func (p *Pad) Directive() string { return "pad" }
 
 type Note struct {
+	Pos         lexer.Position
 	Date        *Date   `parser:"@Date 'note'"`
 	Account     Account `parser:"@Account"`
 	Description string  `parser:"@String"`
@@ -131,6 +137,7 @@ func (n *Note) date() *Date       { return n.Date }
 func (n *Note) Directive() string { return "note" }
 
 type Document struct {
+	Pos            lexer.Position
 	Date           *Date   `parser:"@Date 'document'"`
 	Account        Account `parser:"@Account"`
 	PathToDocument string  `parser:"@String"`
@@ -144,6 +151,7 @@ func (d *Document) date() *Date       { return d.Date }
 func (d *Document) Directive() string { return "document" }
 
 type Price struct {
+	Pos       lexer.Position
 	Date      *Date   `parser:"@Date 'price'"`
 	Commodity string  `parser:"@Ident"`
 	Amount    *Amount `parser:"@@"`
@@ -157,6 +165,7 @@ func (p *Price) date() *Date       { return p.Date }
 func (p *Price) Directive() string { return "price" }
 
 type Event struct {
+	Pos   lexer.Position
 	Date  *Date  `parser:"@Date 'event'"`
 	Name  string `parser:"@String"`
 	Value string `parser:"@String"`
@@ -170,6 +179,7 @@ func (e *Event) date() *Date       { return e.Date }
 func (e *Event) Directive() string { return "event" }
 
 type Transaction struct {
+	Pos       lexer.Position
 	Date      *Date  `parser:"@Date ('txn' | "`
 	Flag      string `parser:"@('*' | '!' | 'P') )"`
 	Payee     string `parser:"@(String (?= String))?"`
@@ -188,6 +198,7 @@ func (t *Transaction) date() *Date       { return t.Date }
 func (t *Transaction) Directive() string { return "transaction" }
 
 type Posting struct {
+	Pos         lexer.Position
 	Flag        string  `parser:"@('*' | '!')?"`
 	Account     Account `parser:"@Account"`
 	Amount      *Amount `parser:"(@@"`
@@ -335,11 +346,13 @@ type Metadata struct {
 }
 
 type Option struct {
+	Pos   lexer.Position
 	Name  string `parser:"'option' @String"`
 	Value string `parser:"@String"`
 }
 
 type Include struct {
+	Pos      lexer.Position
 	Filename string `parser:"'include' @String"`
 }
 
@@ -355,7 +368,7 @@ var (
 		{"Punct", `[!*:,@{}]`},
 		{"Comment", `;[^\n]*\n`},
 		{"Whitespace", `[[:space:]]`},
-		{"ignore", `[\s\S]*`},
+		{"ignore", `.`},
 	})
 
 	parser = participle.MustBuild[AST](


### PR DESCRIPTION
Adds a comprehensive formatter for beancount files with proper currency alignment and comment/blank line preservation.

```sh
beancount format ledger.beancount
```