### PR TITLE
feat(parser): add arithmetic expressions in amounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,13 +470,20 @@ func TestFormatCmd(t *testing.T) {
 
 ### Assertion Library
 
-Use `github.com/alecthomas/assert/v2` for assertions:
+**REQUIRED:** All tests MUST use `github.com/alecthomas/assert/v2` for assertions:
 
 ```go
 assert.NoError(t, err)
 assert.Equal(t, expected, actual)
 assert.True(t, condition, "optional message")
+assert.Error(t, err, "expected an error")
+assert.NotEqual(t, nil, value, "expected non-nil value")
 ```
+
+**DO NOT use:**
+- `if err != nil { t.Fatalf(...) }`
+- `if got != want { t.Errorf(...) }`
+- Manual error checking in tests
 
 ### Test Coverage
 
@@ -928,7 +935,8 @@ txn := ast.NewClearedTransaction(date, csvPayee,
     ast.NewPosting(checkingAccount, ast.WithAmount(csvAmount, "USD")),
 )
 
-formatter.FormatTransaction(txn, os.Stdout)
+fmtr := formatter.New()
+fmtr.FormatTransaction(txn, os.Stdout)
 ```
 
 **Rules:**

--- a/README.md
+++ b/README.md
@@ -191,8 +191,9 @@ fmtr := formatter.New()
 // Format a single transaction
 fmtr.FormatTransaction(txn, os.Stdout)
 
-// Format an entire AST
-fmtr.Format(context.Background(), ast, sourceContent, os.Stdout)
+// Format an entire AST with expression preservation
+fmtr := formatter.New(formatter.WithSource(sourceContent))
+fmtr.Format(context.Background(), ast, os.Stdout)
 ```
 
 ### Complete Example

--- a/ast/position.go
+++ b/ast/position.go
@@ -10,6 +10,27 @@ type Position struct {
 	Column   int // Column number (1-indexed)
 }
 
+// Span represents a range in the source file.
+// Used to preserve original source text for formatting (e.g., expressions like "(100 + 50)").
+type Span struct {
+	Start int // Starting byte offset (inclusive)
+	End   int // Ending byte offset (exclusive)
+}
+
+// IsZero returns true if this is an uninitialized span.
+func (s Span) IsZero() bool {
+	return s.Start == 0 && s.End == 0
+}
+
+// Text extracts the source text for this span (zero-copy slice).
+// Returns empty string if span is invalid or zero.
+func (s Span) Text(source []byte) string {
+	if s.IsZero() || s.Start < 0 || s.End <= s.Start || s.End > len(source) {
+		return ""
+	}
+	return string(source[s.Start:s.End])
+}
+
 // String returns a human-readable representation of the position.
 func (p Position) String() string {
 	if p.Filename != "" {

--- a/ast/position_test.go
+++ b/ast/position_test.go
@@ -1,0 +1,77 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestSpan_Text(t *testing.T) {
+	source := []byte("hello world")
+
+	t.Run("Valid span", func(t *testing.T) {
+		span := Span{Start: 0, End: 5}
+		result := span.Text(source)
+		assert.Equal(t, "hello", result)
+	})
+
+	t.Run("Valid span in middle", func(t *testing.T) {
+		span := Span{Start: 6, End: 11}
+		result := span.Text(source)
+		assert.Equal(t, "world", result)
+	})
+
+	t.Run("Zero span", func(t *testing.T) {
+		span := Span{Start: 0, End: 0}
+		result := span.Text(source)
+		assert.Equal(t, "", result, "zero span should return empty string")
+	})
+
+	t.Run("Negative start", func(t *testing.T) {
+		span := Span{Start: -5, End: 3}
+		result := span.Text(source)
+		assert.Equal(t, "", result, "negative start should return empty string")
+	})
+
+	t.Run("Start greater than End", func(t *testing.T) {
+		span := Span{Start: 10, End: 5}
+		result := span.Text(source)
+		assert.Equal(t, "", result, "start > end should return empty string")
+	})
+
+	t.Run("End beyond source length", func(t *testing.T) {
+		span := Span{Start: 0, End: 100}
+		result := span.Text(source)
+		assert.Equal(t, "", result, "end > len(source) should return empty string")
+	})
+
+	t.Run("Start beyond source length", func(t *testing.T) {
+		span := Span{Start: 100, End: 105}
+		result := span.Text(source)
+		assert.Equal(t, "", result, "start > len(source) should return empty string")
+	})
+
+	t.Run("Empty source", func(t *testing.T) {
+		emptySource := []byte("")
+		span := Span{Start: 0, End: 5}
+		result := span.Text(emptySource)
+		assert.Equal(t, "", result, "should handle empty source gracefully")
+	})
+}
+
+func TestSpan_IsZero(t *testing.T) {
+	t.Run("Zero span", func(t *testing.T) {
+		span := Span{Start: 0, End: 0}
+		assert.True(t, span.IsZero(), "zero span should be zero")
+	})
+
+	t.Run("Non-zero span", func(t *testing.T) {
+		span := Span{Start: 0, End: 5}
+		assert.True(t, !span.IsZero(), "non-zero span should not be zero")
+	})
+
+	t.Run("Negative values are not zero", func(t *testing.T) {
+		span := Span{Start: -1, End: -1}
+		assert.True(t, !span.IsZero(), "negative values should not be considered zero")
+	})
+}

--- a/ast/types.go
+++ b/ast/types.go
@@ -13,6 +13,7 @@ import (
 type Amount struct {
 	Value    string `parser:"@Number"`
 	Currency string `parser:"@Ident"`
+	Span     Span   // Source span for preserving original formatting (e.g., expressions)
 }
 
 // Cost represents the cost basis specification for a posting, used primarily for tracking
@@ -33,6 +34,7 @@ type Cost struct {
 	Amount  *Amount `parser:"| @@)?"`
 	Date    *Date   `parser:"(',' @Date)?"`
 	Label   string  `parser:"(',' @String)? '}'"`
+	Span    Span    // Source span for preserving original cost syntax
 }
 
 // IsEmpty returns true if this is an empty cost specification {}.

--- a/commands.go
+++ b/commands.go
@@ -179,6 +179,7 @@ func (cmd *FormatCmd) Run(ctx *kong.Context, globals *Globals, signalCtx context
 
 	// Create formatter with options
 	var opts []formatter.Option
+	opts = append(opts, formatter.WithSource(contents))
 	if cmd.CurrencyColumn > 0 {
 		opts = append(opts, formatter.WithCurrencyColumn(cmd.CurrencyColumn))
 	}
@@ -191,7 +192,7 @@ func (cmd *FormatCmd) Run(ctx *kong.Context, globals *Globals, signalCtx context
 	f := formatter.New(opts...)
 
 	// Format and output to stdout
-	if err := f.Format(runCtx, ast, contents, ctx.Stdout); err != nil {
+	if err := f.Format(runCtx, ast, ctx.Stdout); err != nil {
 		return err
 	}
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -26,9 +26,9 @@ option "title" "Test"
 		assert.NoError(t, err)
 
 		// Format to buffer
-		f := formatter.New()
+		f := formatter.New(formatter.WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -50,9 +50,9 @@ option "title" "Test"
 		assert.NoError(t, err)
 
 		// Format with custom column
-		f := formatter.New(formatter.WithCurrencyColumn(60))
+		f := formatter.New(formatter.WithSource([]byte(source)), formatter.WithCurrencyColumn(60))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -68,9 +68,9 @@ option "title" "Test"
 		ast, err := parser.ParseBytes(context.Background(), []byte(source))
 		assert.NoError(t, err)
 
-		f := formatter.New()
+		f := formatter.New(formatter.WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Empty file produces minimal output
@@ -98,9 +98,9 @@ option "title" "Integration Test"
 		ast, err := parser.ParseBytes(context.Background(), []byte(source))
 		assert.NoError(t, err)
 
-		f := formatter.New()
+		f := formatter.New(formatter.WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()

--- a/formatter/comments_test.go
+++ b/formatter/comments_test.go
@@ -20,9 +20,9 @@ option "title" "Test"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Verify comments are preserved
@@ -42,9 +42,9 @@ option "title" "Test"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -74,9 +74,9 @@ option "title" "Test"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		assert.True(t, bytes.Contains(buf.Bytes(), []byte("; Opening accounts")),
@@ -92,9 +92,9 @@ option "title" "Test"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New(WithPreserveComments(false))
+		f := New(WithSource([]byte(source)), WithPreserveComments(false))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Comment should not be in output
@@ -110,9 +110,9 @@ option "title" "Test"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New(WithPreserveBlanks(false))
+		f := New(WithSource([]byte(source)), WithPreserveBlanks(false))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have minimal blank lines
@@ -139,9 +139,9 @@ option "title" "Test"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// All comments should be preserved
@@ -233,9 +233,9 @@ option "operating_currency" "EUR"
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Verify hash headers are preserved

--- a/formatter/expression_preservation_test.go
+++ b/formatter/expression_preservation_test.go
@@ -1,0 +1,244 @@
+package formatter
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+func TestExpressionPreservation(t *testing.T) {
+	t.Run("Format preserves expressions", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test expressions"
+  Assets:Cash         (10 + 20) USD
+  Expenses:Food       100 / 3 EUR
+  Expenses:Transport  -50.00 USD
+  Assets:Bank`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+
+		// Check that expressions are preserved
+		assert.True(t, strings.Contains(output, "(10 + 20)"), "expected expression '(10 + 20)' to be preserved")
+		assert.True(t, strings.Contains(output, "100 / 3"), "expected expression '100 / 3' to be preserved")
+		assert.True(t, strings.Contains(output, "-50.00"), "expected '-50.00' to be preserved")
+	})
+
+	t.Run("FormatTransaction with source preserves expressions", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test"
+  Assets:Cash  (10 + 20) USD
+  Assets:Bank`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		txn, ok := tree.Directives[0].(*ast.Transaction)
+		assert.True(t, ok, "expected Transaction directive")
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+
+		// With source - should preserve expressions
+		err = f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "(10 + 20)"), "expected expression '(10 + 20)' to be preserved with source")
+	})
+
+	t.Run("FormatTransaction without source shows evaluated values", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test"
+  Assets:Cash  (10 + 20) USD
+  Assets:Bank`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		txn, ok := tree.Directives[0].(*ast.Transaction)
+		assert.True(t, ok, "expected Transaction directive")
+
+		var buf bytes.Buffer
+		f := New() // No WithSource - should show evaluated values
+
+		// Without source - should show evaluated value
+		err = f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, !strings.Contains(output, "(10 + 20)"), "expected expression to be evaluated without source")
+		assert.True(t, strings.Contains(output, "30"), "expected evaluated value '30' without source")
+	})
+
+	t.Run("Cost expressions preserved", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Buy stock"
+  Assets:Stock  10 STOCK {(100 + 50) USD}
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "{(100 + 50) USD}"), "expected cost expression to be preserved")
+	})
+
+	t.Run("Expression alignment", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test alignment"
+  Assets:Cash         100.00 USD
+  Expenses:Food    (10 + 20) USD
+  Expenses:Other        5.00 USD
+  Assets:Bank`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		lines := strings.Split(output, "\n")
+
+		// Find currency positions for each line
+		var currencyPositions []int
+		for _, line := range lines {
+			if strings.Contains(line, "USD") {
+				pos := strings.Index(line, "USD")
+				currencyPositions = append(currencyPositions, pos)
+			}
+		}
+
+		// All currency positions should be the same (aligned)
+		assert.True(t, len(currencyPositions) > 1, "expected multiple USD positions")
+		firstPos := currencyPositions[0]
+		for i, pos := range currencyPositions {
+			assert.Equal(t, firstPos, pos, "currency misaligned at line %d", i)
+		}
+	})
+
+	t.Run("Price annotation expressions preserved", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test price annotations"
+  Assets:Stock  10 AAPL @ (100 + 50) USD
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "@ (100 + 50) USD"), "expected price expression '@ (100 + 50) USD' to be preserved")
+	})
+
+	t.Run("Total price annotation expressions preserved", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test total price annotations"
+  Assets:Stock  10 AAPL @@ (100 * 10) USD
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "@@ (100 * 10) USD"), "expected total price expression '@@ (100 * 10) USD' to be preserved")
+	})
+
+	t.Run("All expression types preserved together", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test all expression types"
+  Assets:Stock  10 AAPL @ (100 + 50) USD
+  Expenses:Food  (20 + 30) EUR
+  Assets:Stock  5 GOOG {(150 * 2) USD}
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "@ (100 + 50) USD"), "expected price expression to be preserved")
+		assert.True(t, strings.Contains(output, "(20 + 30) EUR"), "expected amount expression to be preserved")
+		assert.True(t, strings.Contains(output, "{(150 * 2) USD}"), "expected cost expression to be preserved")
+	})
+
+	t.Run("Merge cost preserved", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test merge cost"
+  Assets:Stock  10 AAPL {*}
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "{*}"), "expected merge cost '{*}' to be preserved")
+	})
+
+	t.Run("Empty cost preserved", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test empty cost"
+  Assets:Stock  10 AAPL {}
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "{}"), "expected empty cost '{}' to be preserved")
+	})
+
+	t.Run("All cost types together", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test all cost types"
+  Assets:Stock  10 AAPL {100.00 USD}
+  Assets:Stock  5 GOOG {*}
+  Assets:Stock  3 MSFT {}
+  Assets:Cash`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		f := New(WithSource(source))
+		err = f.Format(context.Background(), tree, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, "{100.00 USD}"), "expected cost with amount")
+		assert.True(t, strings.Contains(output, "{*}"), "expected merge cost")
+		assert.True(t, strings.Contains(output, "{}"), "expected empty cost")
+	})
+}

--- a/formatter/formatter_bench_test.go
+++ b/formatter/formatter_bench_test.go
@@ -26,13 +26,13 @@ option "title" "Test Ledger"
 			b.Fatal(err)
 		}
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
 			var buf bytes.Buffer
-			if err := f.Format(context.Background(), ast, []byte(source), &buf); err != nil {
+			if err := f.Format(context.Background(), ast, &buf); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -65,13 +65,13 @@ option "operating_currency" "USD"
 			b.Fatal(err)
 		}
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
 			var buf bytes.Buffer
-			if err := f.Format(context.Background(), ast, []byte(source), &buf); err != nil {
+			if err := f.Format(context.Background(), ast, &buf); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -100,13 +100,13 @@ option "operating_currency" "USD"
 			b.Fatal(err)
 		}
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
 			var buf bytes.Buffer
-			if err := f.Format(context.Background(), ast, []byte(source), &buf); err != nil {
+			if err := f.Format(context.Background(), ast, &buf); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -133,13 +133,13 @@ option "title" "Test Ledger"
 			b.Fatal(err)
 		}
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
 			var buf bytes.Buffer
-			if err := f.Format(context.Background(), ast, []byte(source), &buf); err != nil {
+			if err := f.Format(context.Background(), ast, &buf); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -159,13 +159,13 @@ option "title" "Test Ledger"
 			b.Fatal(err)
 		}
 
-		f := New(WithPreserveComments(false), WithPreserveBlanks(false))
+		f := New(WithSource([]byte(source)), WithPreserveComments(false), WithPreserveBlanks(false))
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
 			var buf bytes.Buffer
-			if err := f.Format(context.Background(), ast, []byte(source), &buf); err != nil {
+			if err := f.Format(context.Background(), ast, &buf); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -72,9 +72,9 @@ func TestFormat(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// For now, just verify no error - actual formatting will be implemented in later steps
@@ -88,9 +88,9 @@ func TestFormat(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New(WithCurrencyColumn(70))
+		f := New(WithSource([]byte(source)), WithCurrencyColumn(70))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 70, f.CurrencyColumn)
@@ -104,9 +104,9 @@ func TestFormat(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have calculated a currency column
@@ -222,9 +222,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "option \"title\" \"My Ledger\"\n"
@@ -236,9 +236,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "include \"2024.beancount\"\n"
@@ -250,9 +250,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-01-01 commodity USD\n"
@@ -264,9 +264,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-01-01 open Assets:Checking\n"
@@ -278,9 +278,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Currencies should have minimal spacing (2 spaces), not aligned
@@ -294,9 +294,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-12-31 close Assets:Checking\n"
@@ -308,9 +308,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have aligned amount
@@ -323,9 +323,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-01-01 pad Assets:Checking Equity:Opening-Balances\n"
@@ -337,9 +337,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-01-01 note Assets:Checking \"Initial balance\"\n"
@@ -351,9 +351,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-01-01 document Assets:Checking \"/path/to/doc.pdf\"\n"
@@ -365,9 +365,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have aligned amount
@@ -380,9 +380,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-01-01 event \"location\" \"New York\"\n"
@@ -398,9 +398,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -424,9 +424,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should contain tags
@@ -443,9 +443,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should contain link
@@ -462,9 +462,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should contain metadata (with quotes)
@@ -480,9 +480,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should contain cost
@@ -498,9 +498,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should contain price
@@ -512,9 +512,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "plugin \"beancount.plugins.auto_accounts\"\n"
@@ -526,9 +526,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "plugin \"beancount.plugins.check_commodity\" \"USD,EUR\"\n"
@@ -540,9 +540,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "2021-06-01 custom \"budget\" \"quarterly\" TRUE 10000.00 USD\n"
@@ -555,9 +555,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -570,9 +570,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "pushtag #vacation\n"
@@ -584,9 +584,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "poptag #vacation\n"
@@ -598,9 +598,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "pushmeta trip: \"NYC Summer 2021\"\n"
@@ -612,9 +612,9 @@ func TestFormatDirectives(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		expected := "popmeta trip:\n"
@@ -633,9 +633,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -667,9 +667,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should handle long account names gracefully
@@ -688,9 +688,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// All amounts should be present and properly aligned
@@ -710,9 +710,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -740,9 +740,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// All currencies should be present and aligned
@@ -760,9 +760,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have both payee and narration quoted
@@ -779,9 +779,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -800,9 +800,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have complete cost specification
@@ -818,9 +818,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have @@ for total price
@@ -837,9 +837,9 @@ func TestTransactionEdgeCases(t *testing.T) {
 		ast, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f := New()
+		f := New(WithSource([]byte(source)))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Should have posting-level metadata properly indented (with quotes)
@@ -859,9 +859,9 @@ func TestFormattingIdempotency(t *testing.T) {
 		ast1, err := parser.ParseString(context.Background(), source)
 		assert.NoError(t, err)
 
-		f1 := New()
+		f1 := New(WithSource([]byte(source)))
 		var buf1 bytes.Buffer
-		err = f1.Format(context.Background(), ast1, []byte(source), &buf1)
+		err = f1.Format(context.Background(), ast1, &buf1)
 		assert.NoError(t, err)
 
 		formatted1 := buf1.String()
@@ -870,9 +870,9 @@ func TestFormattingIdempotency(t *testing.T) {
 		ast2, err := parser.ParseString(context.Background(), formatted1)
 		assert.NoError(t, err)
 
-		f2 := New()
+		f2 := New(WithSource([]byte(formatted1)))
 		var buf2 bytes.Buffer
-		err = f2.Format(context.Background(), ast2, []byte(formatted1), &buf2)
+		err = f2.Format(context.Background(), ast2, &buf2)
 		assert.NoError(t, err)
 
 		formatted2 := buf2.String()
@@ -893,9 +893,9 @@ func TestFormatterWidthOptions(t *testing.T) {
 
 	t.Run("WithCurrencyColumn", func(t *testing.T) {
 		// CurrencyColumn overrides other options
-		f := New(WithCurrencyColumn(60))
+		f := New(WithSource([]byte(source)), WithCurrencyColumn(60))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Currency should be at column 60
@@ -906,9 +906,9 @@ func TestFormatterWidthOptions(t *testing.T) {
 
 	t.Run("WithPrefixWidth", func(t *testing.T) {
 		// Only set prefix width, num width auto-calculated
-		f := New(WithPrefixWidth(40))
+		f := New(WithSource([]byte(source)), WithPrefixWidth(40))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -918,9 +918,9 @@ func TestFormatterWidthOptions(t *testing.T) {
 
 	t.Run("WithNumWidth", func(t *testing.T) {
 		// Only set num width, prefix width auto-calculated
-		f := New(WithNumWidth(15))
+		f := New(WithSource([]byte(source)), WithNumWidth(15))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		output := buf.String()
@@ -930,9 +930,9 @@ func TestFormatterWidthOptions(t *testing.T) {
 
 	t.Run("WithPrefixAndNumWidth", func(t *testing.T) {
 		// Both prefix and num width set
-		f := New(WithPrefixWidth(40), WithNumWidth(12))
+		f := New(WithSource([]byte(source)), WithPrefixWidth(40), WithNumWidth(12))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// Currency column should be 40 + 12 = 52
@@ -945,9 +945,9 @@ func TestFormatterWidthOptions(t *testing.T) {
 
 	t.Run("CurrencyColumnOverridesPrefixAndNumWidth", func(t *testing.T) {
 		// CurrencyColumn should override PrefixWidth and NumWidth
-		f := New(WithCurrencyColumn(70), WithPrefixWidth(40), WithNumWidth(12))
+		f := New(WithSource([]byte(source)), WithCurrencyColumn(70), WithPrefixWidth(40), WithNumWidth(12))
 		var buf bytes.Buffer
-		err = f.Format(context.Background(), ast, []byte(source), &buf)
+		err = f.Format(context.Background(), ast, &buf)
 		assert.NoError(t, err)
 
 		// CurrencyColumn should be 70 (not 40 + 12 = 52)

--- a/formatter/metadata_test.go
+++ b/formatter/metadata_test.go
@@ -1,0 +1,205 @@
+package formatter
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+func TestMetadataEscaping(t *testing.T) {
+	t.Run("Programmatic metadata with quote", func(t *testing.T) {
+		date, _ := ast.NewDate("2023-01-01")
+		acct, _ := ast.NewAccount("Assets:Cash")
+
+		txn := ast.NewTransaction(date, "Test",
+			ast.WithFlag("*"),
+			ast.WithPostings(
+				ast.NewPosting(acct, ast.WithAmount("100.00", "USD")),
+			),
+		)
+
+		// Add metadata with a quote - should be escaped
+		txn.Metadata = []*ast.Metadata{
+			{Key: "note", Value: `He said "hello"`},
+		}
+
+		f := New()
+		var buf bytes.Buffer
+		err := f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, `note: "He said \"hello\"`), "quote should be escaped")
+		assert.True(t, !strings.Contains(output, `"He said "hello""`), "unescaped quote would break syntax")
+	})
+
+	t.Run("Programmatic metadata with backslash", func(t *testing.T) {
+		date, _ := ast.NewDate("2023-01-01")
+		acct, _ := ast.NewAccount("Assets:Cash")
+
+		txn := ast.NewTransaction(date, "Test",
+			ast.WithFlag("*"),
+			ast.WithPostings(
+				ast.NewPosting(acct, ast.WithAmount("100.00", "USD")),
+			),
+		)
+
+		// Add metadata with a backslash (e.g., Windows path)
+		txn.Metadata = []*ast.Metadata{
+			{Key: "file", Value: `C:\Users\Documents\receipt.pdf`},
+		}
+
+		f := New()
+		var buf bytes.Buffer
+		err := f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, `file: "C:\\Users\\Documents\\receipt.pdf"`), "backslashes should be escaped")
+	})
+
+	t.Run("Programmatic metadata with both quote and backslash", func(t *testing.T) {
+		date, _ := ast.NewDate("2023-01-01")
+		acct, _ := ast.NewAccount("Assets:Cash")
+
+		txn := ast.NewTransaction(date, "Test",
+			ast.WithFlag("*"),
+			ast.WithPostings(
+				ast.NewPosting(acct, ast.WithAmount("100.00", "USD")),
+			),
+		)
+
+		// Add metadata with both special characters
+		txn.Metadata = []*ast.Metadata{
+			{Key: "note", Value: `Path "C:\temp" exists`},
+		}
+
+		f := New()
+		var buf bytes.Buffer
+		err := f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, `note: "Path \"C:\\temp\" exists"`), "both quote and backslash should be escaped")
+	})
+
+	t.Run("Programmatic metadata with plain text", func(t *testing.T) {
+		date, _ := ast.NewDate("2023-01-01")
+		acct, _ := ast.NewAccount("Assets:Cash")
+
+		txn := ast.NewTransaction(date, "Test",
+			ast.WithFlag("*"),
+			ast.WithPostings(
+				ast.NewPosting(acct, ast.WithAmount("100.00", "USD")),
+			),
+		)
+
+		// Add metadata with no special characters
+		txn.Metadata = []*ast.Metadata{
+			{Key: "note", Value: "Plain text no escapes needed"},
+		}
+
+		f := New()
+		var buf bytes.Buffer
+		err := f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, `note: "Plain text no escapes needed"`), "plain text should remain unchanged")
+	})
+
+	t.Run("Parsed metadata with escapes", func(t *testing.T) {
+		// Verify that parsing unescapes string content so formatting remains idempotent.
+		source := []byte(`2023-01-01 * "Test"
+  note: "This has a \" quote"
+  Assets:Cash  100.00 USD
+`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		txn, ok := tree.Directives[0].(*ast.Transaction)
+		assert.True(t, ok, "expected Transaction directive")
+		assert.Equal(t, 1, len(txn.Metadata))
+		assert.Equal(t, `This has a " quote`, txn.Metadata[0].Value)
+
+		f := New(WithSource(source))
+		var buf bytes.Buffer
+		err = f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+
+		assert.True(t, strings.Contains(output, `note: "This has a \" quote"`), "escapes should be preserved once")
+		assert.False(t, strings.Contains(output, `\\\"`), "escapes must not be doubled")
+	})
+
+	t.Run("Parsed metadata with negative number", func(t *testing.T) {
+		source := []byte(`2023-01-01 * "Test"
+  price: -45.00 USD
+  Assets:Cash  100.00 USD
+`)
+
+		tree, err := parser.ParseBytes(context.Background(), source)
+		assert.NoError(t, err)
+
+		txn, ok := tree.Directives[0].(*ast.Transaction)
+		assert.True(t, ok, "expected Transaction directive")
+		assert.Equal(t, 1, len(txn.Metadata))
+		assert.Equal(t, `-45.00 USD`, txn.Metadata[0].Value)
+
+		f := New(WithSource(source))
+		var buf bytes.Buffer
+		err = f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		assert.True(t, strings.Contains(output, `price: "-45.00 USD"`), "value should preserve minus without extra spaces")
+	})
+
+	t.Run("Multiple metadata entries", func(t *testing.T) {
+		date, _ := ast.NewDate("2023-01-01")
+		acct, _ := ast.NewAccount("Assets:Cash")
+
+		txn := ast.NewTransaction(date, "Test",
+			ast.WithFlag("*"),
+			ast.WithPostings(
+				ast.NewPosting(acct, ast.WithAmount("100.00", "USD")),
+			),
+		)
+
+		txn.Metadata = []*ast.Metadata{
+			{Key: "note1", Value: "Plain"},
+			{Key: "note2", Value: `Has "quote"`},
+			{Key: "note3", Value: `Has \backslash`},
+			{Key: "note4", Value: `Has "both" \things`},
+		}
+
+		f := New()
+		var buf bytes.Buffer
+		err := f.FormatTransaction(txn, &buf)
+		assert.NoError(t, err)
+
+		output := buf.String()
+		lines := strings.Split(output, "\n")
+
+		// Verify each metadata line exists with proper escaping
+		var metadataLines []string
+		for _, line := range lines {
+			if strings.Contains(line, "note") {
+				metadataLines = append(metadataLines, strings.TrimSpace(line))
+			}
+		}
+
+		assert.Equal(t, 4, len(metadataLines))
+		assert.Equal(t, `note1: "Plain"`, metadataLines[0])
+		assert.Equal(t, `note2: "Has \"quote\""`, metadataLines[1])
+		assert.Equal(t, `note3: "Has \\backslash"`, metadataLines[2])
+		assert.Equal(t, `note4: "Has \"both\" \\things"`, metadataLines[3])
+	})
+}

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1,0 +1,163 @@
+package parser
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+// Expression parsing for arithmetic expressions in amounts.
+//
+// Supports:
+//   - Binary operators: +, -, *, /
+//   - Parentheses for grouping
+//   - Decimal numbers with proper precision
+//
+// Operator precedence (low to high):
+//   1. + -     (addition, subtraction)
+//   2. * /     (multiplication, division)
+//   3. ( )     (parentheses, highest)
+//
+// Grammar:
+//   expression  → term (('+' | '-') term)*
+//   term        → factor (('*' | '/') factor)*
+//   factor      → NUMBER | '(' expression ')'
+//
+// Examples:
+//   2 + 3           → 5
+//   2 + 3 * 4       → 14 (multiplication has higher precedence)
+//   (2 + 3) * 4     → 20 (parentheses override precedence)
+//   40.00 / 3       → 13.333...
+//   ((40.00/3) + 5) → 18.333...
+
+// parseExpression parses and evaluates an arithmetic expression.
+// This is the entry point for expression parsing.
+func (p *Parser) parseExpression() (decimal.Decimal, error) {
+	return p.parseAddSubtract()
+}
+
+// parseAddSubtract handles addition and subtraction (lowest precedence).
+func (p *Parser) parseAddSubtract() (decimal.Decimal, error) {
+	left, err := p.parseMultiplyDivide()
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	for {
+		op := p.peek().Type
+		if op != PLUS && op != MINUS {
+			break
+		}
+
+		p.advance() // consume operator
+
+		right, err := p.parseMultiplyDivide()
+		if err != nil {
+			return decimal.Zero, err
+		}
+
+		switch op {
+		case PLUS:
+			left = left.Add(right)
+		case MINUS:
+			left = left.Sub(right)
+		}
+	}
+
+	return left, nil
+}
+
+// parseMultiplyDivide handles multiplication and division (higher precedence).
+func (p *Parser) parseMultiplyDivide() (decimal.Decimal, error) {
+	left, err := p.parsePrimary()
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	for {
+		op := p.peek().Type
+		if op != ASTERISK && op != SLASH {
+			break
+		}
+
+		opToken := p.advance() // consume operator
+
+		right, err := p.parsePrimary()
+		if err != nil {
+			return decimal.Zero, err
+		}
+
+		switch op {
+		case ASTERISK:
+			left = left.Mul(right)
+		case SLASH:
+			if right.IsZero() {
+				return decimal.Zero, p.errorAtToken(opToken, "division by zero")
+			}
+			left = left.Div(right)
+		}
+	}
+
+	return left, nil
+}
+
+// parsePrimary handles numbers and parenthesized expressions (highest precedence).
+func (p *Parser) parsePrimary() (decimal.Decimal, error) {
+	tok := p.peek()
+
+	// Parenthesized expression: (expr)
+	if tok.Type == LPAREN {
+		p.advance() // consume '('
+
+		result, err := p.parseExpression()
+		if err != nil {
+			return decimal.Zero, err
+		}
+
+		if !p.check(RPAREN) {
+			return decimal.Zero, p.error("expected ')' after expression")
+		}
+		p.advance() // consume ')'
+
+		return result, nil
+	}
+
+	// Number (possibly negative)
+	if tok.Type == NUMBER {
+		numTok := p.advance()
+		value := numTok.String(p.source)
+
+		d, err := decimal.NewFromString(value)
+		if err != nil {
+			return decimal.Zero, p.errorAtToken(numTok, "invalid number in expression: %v", err)
+		}
+
+		return d, nil
+	}
+
+	// Handle unary minus: -expr
+	if tok.Type == MINUS {
+		p.advance() // consume '-'
+
+		value, err := p.parsePrimary()
+		if err != nil {
+			return decimal.Zero, err
+		}
+
+		return value.Neg(), nil
+	}
+
+	return decimal.Zero, p.errorAtToken(tok, "expected number or '(' in expression, got %s", tok.Type)
+}
+
+// isExpressionStart checks if the current position looks like the start of an expression.
+// This is used by parseAmount to detect expressions vs simple numbers.
+func (p *Parser) isExpressionStart() bool {
+	// Check if we have: NUMBER followed by an operator (+, -, *, /)
+	if p.check(NUMBER) {
+		nextTok := p.peekAhead(1)
+		return nextTok.Type == PLUS || nextTok.Type == MINUS ||
+			nextTok.Type == ASTERISK || nextTok.Type == SLASH
+	}
+
+	// Check if we start with a parenthesis or minus (definitely an expression)
+	return p.check(LPAREN) || p.check(MINUS)
+}

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -1,0 +1,314 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/shopspring/decimal"
+)
+
+// Helper function to parse an expression from a string
+func parseExpressionFromString(t *testing.T, input string) (decimal.Decimal, error) {
+	t.Helper()
+
+	// Lex the input
+	lexer := NewLexer([]byte(input), "test")
+	tokens := lexer.ScanAll()
+
+	// Create parser
+	parser := NewParser([]byte(input), tokens, "test", lexer.Interner())
+
+	// Parse expression
+	return parser.parseExpression()
+}
+
+func TestParseExpression_SimpleAddition(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"2 + 3", "5"},
+		{"10 + 5", "15"},
+		{"1.5 + 2.5", "4"},
+		{"100.00 + 50.00", "150"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_SimpleSubtraction(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"5 - 3", "2"},
+		{"10 - 5", "5"},
+		{"100.00 - 25.50", "74.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_SimpleMultiplication(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"2 * 3", "6"},
+		{"5 * 4", "20"},
+		{"1.5 * 2", "3"},
+		{"10.00 * 3.5", "35"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_SimpleDivision(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"6 / 2", "3"},
+		{"10 / 2", "5"},
+		{"40.00 / 3", "13.3333333333333333"}, // shopspring/decimal default precision
+		{"100 / 4", "25"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_OperatorPrecedence(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"2 + 3 * 4", "14"},     // 2 + (3 * 4) = 2 + 12 = 14
+		{"10 - 2 * 3", "4"},     // 10 - (2 * 3) = 10 - 6 = 4
+		{"20 / 4 + 5", "10"},    // (20 / 4) + 5 = 5 + 5 = 10
+		{"2 * 3 + 4 * 5", "26"}, // (2 * 3) + (4 * 5) = 6 + 20 = 26
+		{"100 / 2 - 10", "40"},  // (100 / 2) - 10 = 50 - 10 = 40
+		{"5 + 10 / 2", "10"},    // 5 + (10 / 2) = 5 + 5 = 10
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_Parentheses(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"(2 + 3)", "5"},
+		{"(2 + 3) * 4", "20"},          // (2 + 3) * 4 = 5 * 4 = 20
+		{"2 * (3 + 4)", "14"},          // 2 * (3 + 4) = 2 * 7 = 14
+		{"(10 - 2) * 3", "24"},         // (10 - 2) * 3 = 8 * 3 = 24
+		{"((2 + 3) * 4)", "20"},        // nested parentheses
+		{"(100 / 4) + (20 / 5)", "29"}, // (100 / 4) + (20 / 5) = 25 + 4 = 29
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_DecimalPrecision(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"40.00 / 3", "13.3333333333333333"}, // shopspring/decimal default precision
+		{"1.5 + 2.7", "4.2"},
+		{"10.123 * 2.5", "25.3075"},
+		{"100.50 - 0.25", "100.25"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_ComplexExpressions(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// From TODO.txt example
+		{"(40.00 / 3) + 5", "18.3333333333333333"}, // shopspring/decimal default precision
+		{"((40.00 / 3) + 5)", "18.3333333333333333"},
+
+		// Other complex cases
+		{"(2 + 3) * (4 + 5)", "45"},
+		{"100 / (2 + 3)", "20"},
+		{"(10 + 20) / (3 - 1)", "15"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_UnaryMinus(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"-5", "-5"},
+		{"-10.50", "-10.5"},
+		{"-(2 + 3)", "-5"},
+		{"-5 + 10", "5"},
+		{"10 + -5", "5"},
+		{"-5 * 2", "-10"},
+		{"-10 / 2", "-5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseExpressionFromString(t, tt.input)
+			assert.NoError(t, err)
+
+			want, _ := decimal.NewFromString(tt.want)
+			assert.True(t, got.Equal(want), "got %s, want %s", got.String(), want.String())
+		})
+	}
+}
+
+func TestParseExpression_DivisionByZero(t *testing.T) {
+	tests := []string{
+		"10 / 0",
+		"5 / (2 - 2)",
+		"100 / (5 - 5)",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := parseExpressionFromString(t, input)
+			assert.Error(t, err, "expected division by zero error")
+			if err != nil && err.Error() != "" {
+				assert.True(t, contains(err.Error(), "division by zero"), "expected 'division by zero' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseExpression_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"missing closing paren", "(2 + 3"},
+		{"missing operand", "2 +"},
+		{"invalid operator sequence", "2 + * 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseExpressionFromString(t, tt.input)
+			assert.Error(t, err, "expected error for %q", tt.input)
+		})
+	}
+}
+
+// Test that expressions work in complete amount parsing
+func TestParseAmount_WithExpression(t *testing.T) {
+	tests := []struct {
+		input        string
+		wantValue    string
+		wantCurrency string
+	}{
+		{"100.50 USD", "100.50", "USD"},
+		{"(40.00 / 3) USD", "13.33333333333333333333333333", "USD"},
+		{"40.00 / 3 + 5 USD", "18.33333333333333333333333333", "USD"},
+		{"(2 + 3) * 4 EUR", "20", "EUR"},
+		// Negative expressions (bug fix verification)
+		{"-5 + 10 USD", "5", "USD"},    // Bug case: negative start of expression
+		{"-10 * 2 USD", "-20", "USD"},  // Negative with multiplication
+		{"-100 / 2 EUR", "-50", "EUR"}, // Negative with division
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			tree, err := ParseString(context.Background(), tt.input)
+			assert.NoError(t, err, "parse error")
+
+			// This won't directly give us an amount, but we can test through
+			// a transaction or other directive. For now, just verify no parse error.
+			assert.NotEqual(t, nil, tree, "expected non-nil tree")
+		})
+	}
+}
+
+// Helper function
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr ||
+		(len(s) > 0 && len(substr) > 0 &&
+			(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+				findSubstring(s, substr))))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/parser/integration_test.go
+++ b/parser/integration_test.go
@@ -3,6 +3,9 @@ package parser
 import (
 	"context"
 	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/ast"
 )
 
 func TestParseSimpleTransaction(t *testing.T) {
@@ -12,13 +15,9 @@ func TestParseSimpleTransaction(t *testing.T) {
 `
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 1 {
-		t.Fatalf("got %d directives, want 1", len(ast.Directives))
-	}
+	assert.Equal(t, 1, len(ast.Directives))
 
 	t.Logf("Successfully parsed transaction!")
 }
@@ -27,13 +26,9 @@ func TestParseBalance(t *testing.T) {
 	input := `2014-08-09 balance Assets:Checking 100.00 USD`
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 1 {
-		t.Fatalf("got %d directives, want 1", len(ast.Directives))
-	}
+	assert.Equal(t, 1, len(ast.Directives))
 
 	t.Logf("Successfully parsed balance!")
 }
@@ -42,13 +37,9 @@ func TestParseOpen(t *testing.T) {
 	input := `2014-01-01 open Assets:Checking USD`
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 1 {
-		t.Fatalf("got %d directives, want 1", len(ast.Directives))
-	}
+	assert.Equal(t, 1, len(ast.Directives))
 
 	t.Logf("Successfully parsed open!")
 }
@@ -65,13 +56,9 @@ func TestParseMultipleDirectives(t *testing.T) {
 `
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 4 {
-		t.Fatalf("got %d directives, want 4", len(ast.Directives))
-	}
+	assert.Equal(t, 4, len(ast.Directives))
 
 	t.Logf("Successfully parsed %d directives!", len(ast.Directives))
 }
@@ -86,13 +73,9 @@ func TestParseWithComments(t *testing.T) {
 `
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 2 {
-		t.Fatalf("got %d directives, want 2", len(ast.Directives))
-	}
+	assert.Equal(t, 2, len(ast.Directives))
 
 	t.Logf("Successfully parsed with comments!")
 }
@@ -104,13 +87,9 @@ func TestParseWithMetadata(t *testing.T) {
 `
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 1 {
-		t.Fatalf("got %d directives, want 1", len(ast.Directives))
-	}
+	assert.Equal(t, 1, len(ast.Directives))
 
 	t.Logf("Successfully parsed with metadata!")
 }
@@ -122,13 +101,124 @@ func TestParseAmountWithoutCurrency(t *testing.T) {
 `
 
 	ast, err := ParseString(context.Background(), input)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(ast.Directives) != 1 {
-		t.Fatalf("got %d directives, want 1", len(ast.Directives))
-	}
+	assert.Equal(t, 1, len(ast.Directives))
 
 	t.Logf("Successfully parsed transaction with amount without currency!")
+}
+
+func TestParseTransaction_WithExpressions(t *testing.T) {
+	// Test the example from TODO.txt
+	input := `2014-10-05 * "Split bill"
+  Liabilities:CreditCard         -45.00 USD
+  Assets:Receivable:John         ((40.00/3) + 5) USD
+  Assets:Receivable:Michael      40.00/3 USD
+  Assets:Receivable:Peter        40.00/3 USD
+`
+
+	tree, err := ParseString(context.Background(), input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(tree.Directives))
+
+	txn, ok := tree.Directives[0].(*ast.Transaction)
+	assert.True(t, ok, "expected Transaction, got %T", tree.Directives[0])
+
+	assert.Equal(t, 4, len(txn.Postings))
+
+	// Check that expressions were evaluated correctly
+	tests := []struct {
+		posting int
+		want    string
+	}{
+		{0, "-45.00"},              // Simple negative preserves formatting
+		{1, "18.3333333333333333"}, // ((40.00/3) + 5)
+		{2, "13.3333333333333333"}, // 40.00/3
+		{3, "13.3333333333333333"}, // 40.00/3
+	}
+
+	for _, tt := range tests {
+		assert.NotEqual(t, nil, txn.Postings[tt.posting].Amount, "posting %d: amount is nil", tt.posting)
+		if txn.Postings[tt.posting].Amount != nil {
+			got := txn.Postings[tt.posting].Amount.Value
+			assert.Equal(t, tt.want, got, "posting %d amount mismatch", tt.posting)
+		}
+	}
+
+	t.Logf("Successfully parsed transaction with expression amounts!")
+}
+
+func TestParseTransaction_MixedAmounts(t *testing.T) {
+	// Test mix of simple and expression amounts
+	input := `2023-01-01 * "Test mixed amounts"
+  Assets:Bank            100.00 USD
+  Expenses:Food          (20 + 5) * 2 USD
+  Expenses:Transport     -10.50 USD
+  Assets:Cash
+`
+
+	tree, err := ParseString(context.Background(), input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(tree.Directives))
+
+	txn, ok := tree.Directives[0].(*ast.Transaction)
+	assert.True(t, ok, "expected Transaction, got %T", tree.Directives[0])
+
+	assert.Equal(t, 4, len(txn.Postings))
+
+	// Verify amounts
+	assert.Equal(t, "100.00", txn.Postings[0].Amount.Value, "posting 0")
+
+	// (20 + 5) * 2 = 25 * 2 = 50
+	assert.Equal(t, "50", txn.Postings[1].Amount.Value, "posting 1")
+
+	// Negative amount (simple negative, preserves formatting)
+	assert.Equal(t, "-10.50", txn.Postings[2].Amount.Value, "posting 2")
+
+	// No amount (will be inferred)
+	assert.Equal(t, nil, txn.Postings[3].Amount, "posting 3: expected nil amount")
+
+	t.Logf("Successfully parsed transaction with mixed amount types!")
+}
+
+func TestParseTransaction_NegativeExpressions(t *testing.T) {
+	// Test negative expressions (bug fix verification)
+	input := `2023-01-15 * "Test negative expressions"
+  Assets:Bank            -5 + 10 USD
+  Expenses:Food          -10 * 2 USD
+  Expenses:Transport     -100 / 2 EUR
+  Assets:Cash
+`
+
+	tree, err := ParseString(context.Background(), input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(tree.Directives))
+
+	txn, ok := tree.Directives[0].(*ast.Transaction)
+	assert.True(t, ok, "expected Transaction, got %T", tree.Directives[0])
+
+	assert.Equal(t, 4, len(txn.Postings))
+
+	// Verify negative expression amounts were evaluated correctly
+	tests := []struct {
+		posting int
+		want    string
+	}{
+		{0, "5"},   // -5 + 10 = 5
+		{1, "-20"}, // -10 * 2 = -20
+		{2, "-50"}, // -100 / 2 = -50
+	}
+
+	for _, tt := range tests {
+		assert.NotEqual(t, nil, txn.Postings[tt.posting].Amount, "posting %d: amount is nil", tt.posting)
+		if txn.Postings[tt.posting].Amount != nil {
+			got := txn.Postings[tt.posting].Amount.Value
+			assert.Equal(t, tt.want, got, "posting %d amount mismatch", tt.posting)
+		}
+	}
+
+	t.Logf("Successfully parsed transaction with negative expression amounts!")
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -94,8 +94,6 @@ func (l *Lexer) scanToken() Token {
 			return l.scanDate(start, startLine, startCol)
 		}
 		return l.scanNumber(start, startLine, startCol)
-	case ch == '-' && l.peekIsDigit():
-		return l.scanNumber(start, startLine, startCol)
 
 	// Strings: "..."
 	case ch == '"':
@@ -130,6 +128,16 @@ func (l *Lexer) scanToken() Token {
 		return Token{LBRACE, start, l.pos, startLine, startCol}
 	case ch == '}':
 		return Token{RBRACE, start, l.pos, startLine, startCol}
+	case ch == '(':
+		return Token{LPAREN, start, l.pos, startLine, startCol}
+	case ch == ')':
+		return Token{RPAREN, start, l.pos, startLine, startCol}
+	case ch == '+':
+		return Token{PLUS, start, l.pos, startLine, startCol}
+	case ch == '/':
+		return Token{SLASH, start, l.pos, startLine, startCol}
+	case ch == '-':
+		return Token{MINUS, start, l.pos, startLine, startCol}
 
 	// @ or @@
 	case ch == '@':
@@ -384,14 +392,6 @@ func (l *Lexer) peek() byte {
 		return 0
 	}
 	return l.source[l.pos]
-}
-
-func (l *Lexer) peekIsDigit() bool {
-	if l.pos >= len(l.source) {
-		return false
-	}
-	ch := l.source[l.pos]
-	return ch >= '0' && ch <= '9'
 }
 
 func (l *Lexer) advance() byte {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -221,9 +221,9 @@ func (p *Parser) parsePushmeta() (*ast.Pushmeta, error) {
 		return nil, err
 	}
 
-	p.consume(COLON, "expected ':'")
+	colon := p.consume(COLON, "expected ':'")
 
-	value := p.parseRestOfLine()
+	value := p.parseRestOfLine(colon.End)
 
 	return &ast.Pushmeta{
 		Pos:   tokenPosition(tok, p.filename),

--- a/parser/token.go
+++ b/parser/token.go
@@ -48,6 +48,10 @@ const (
 	ATAT     // @@
 	LBRACE   // {
 	RBRACE   // }
+	LPAREN   // (
+	RPAREN   // )
+	PLUS     // +
+	SLASH    // /
 	MINUS    // - (for negative numbers)
 )
 
@@ -91,6 +95,10 @@ var tokenNames = map[TokenType]string{
 	ATAT:     "@@",
 	LBRACE:   "{",
 	RBRACE:   "}",
+	LPAREN:   "(",
+	RPAREN:   ")",
+	PLUS:     "+",
+	SLASH:    "/",
 	MINUS:    "-",
 }
 

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -153,8 +153,8 @@ func (p *Parser) parsePosting() (*ast.Posting, error) {
 	}
 	posting.Account = account
 
-	// Optional amount
-	if p.check(NUMBER) || p.check(MINUS) {
+	// Optional amount (simple number, expression, or negative)
+	if p.check(NUMBER) || p.check(MINUS) || p.check(LPAREN) {
 		amount, err := p.parseAmountOptional()
 		if err != nil {
 			return nil, err

--- a/testdata/expressions.beancount
+++ b/testdata/expressions.beancount
@@ -1,0 +1,64 @@
+;; Test file for arithmetic expressions in amounts
+;; Demonstrates the expression feature added per TODO.txt
+
+option "title" "Expression Examples"
+option "operating_currency" "USD"
+
+;; Example from TODO.txt - splitting a bill
+2014-10-05 * "Split bill at restaurant"
+  Liabilities:CreditCard         -45.00 USD
+  Assets:Receivable:John         ((40.00/3) + 5) USD  ; John's share plus tip
+  Assets:Receivable:Michael      40.00/3 USD          ; Michael's share
+  Assets:Receivable:Peter        40.00/3 USD          ; Peter's share
+
+;; Simple arithmetic operations
+2023-01-15 * "Groceries with calculation"
+  Expenses:Food:Groceries        10 + 5 + 3.50 USD    ; Total of items
+  Assets:Cash
+
+2023-01-16 * "Fuel - calculated amount"
+  Expenses:Transport:Fuel        15.5 * 1.2 USD       ; Liters × price per liter
+  Assets:Cash
+
+;; Using parentheses for precedence
+2023-02-01 * "Investment return calculation"
+  Assets:Investment:Stocks       (100 + 50) * 1.05 USD  ; Principal plus gain
+  Income:Investment:Gains
+
+;; Division for splitting costs
+2023-02-10 * "Shared expense"
+  Expenses:Utilities:Internet    60.00 / 3 USD  ; Split among 3 roommates
+  Assets:Receivable:Roommate1    60.00 / 3 USD
+  Assets:Receivable:Roommate2    60.00 / 3 USD
+  Assets:Cash                    -60.00 USD
+
+;; Complex expression with multiple operations
+2023-03-05 * "Monthly budget calculation"
+  Expenses:Budget:Entertainment  (100 - 25) + (50 * 0.5) USD  ; Adjusted budget
+  Assets:Checking
+
+;; Negative amounts in expressions
+2023-04-01 * "Refund calculation"
+  Assets:Bank                    -(100 - 15) USD  ; Refund after deduction
+  Expenses:Services
+
+;; Expression in cost specification
+2023-05-10 * "Stock purchase with calculated cost"
+  Assets:Investment:AAPL         10 AAPL {150.00 / 1.05 USD}  ; Cost basis adjustment
+  Assets:Cash                    -(10 * (150.00 / 1.05)) USD
+
+;; Mixed: simple and expression amounts in same transaction
+2023-06-15 * "Shopping trip"
+  Expenses:Food                  50.00 USD              ; Simple amount
+  Expenses:Clothes               (100 - 20) USD         ; Discounted price
+  Expenses:Transport             10 + 5 USD             ; Taxi + tip
+  Assets:Cash                    -165.00 USD            ; Total
+
+;; Edge case: very precise division
+2023-07-20 * "Precise calculation"
+  Expenses:Test                  100.00 / 3 USD  ; Results in repeating decimal
+  Assets:Cash                    -33.34 USD      ; Rounded for balance
+
+2023-07-20 * "Balance the precise calculation"
+  Assets:Cash                    0.01 USD  ; Rounding adjustment
+  Equity:Rounding


### PR DESCRIPTION
Adds support for arithmetic expressions in posting amounts, enabling calculations directly in the Beancount syntax. Expressions are evaluated at parse time using shopspring/decimal for accurate decimal arithmetic, maintaining the zero-allocation architecture.