### PR TITLE
test(fuzz): add native Go fuzzing for parser, lexer, and formatter

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,53 @@
+name: Fuzz
+
+on: 
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz-parser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: jidicula/go-fuzz-action@0da0c6cbe9f19230f0fa62aad18def16d0d23796
+        with:
+          packages: ./parser
+          fuzz-time: 30s
+          fuzz-regexp: FuzzParser
+          fuzz-minimize-time: 1m
+          go-version: "1.25"
+
+  fuzz-lexer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: jidicula/go-fuzz-action@0da0c6cbe9f19230f0fa62aad18def16d0d23796
+        with:
+          packages: ./parser
+          fuzz-time: 30s
+          fuzz-regexp: FuzzLexer
+          fuzz-minimize-time: 1m
+          go-version: "1.25"
+
+  fuzz-formatter:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: jidicula/go-fuzz-action@0da0c6cbe9f19230f0fa62aad18def16d0d23796
+        with:
+          packages: ./formatter
+          fuzz-time: 30s
+          fuzz-regexp: FuzzFormatter
+          fuzz-minimize-time: 1m
+          go-version: "1.25"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,6 +739,28 @@ assert.NotEqual(t, nil, value, "expected non-nil value")
 - Focus on critical paths and error cases
 - Don't test trivial getters/setters
 
+### Fuzz Testing
+
+```bash
+# Quick fuzz check before committing
+go test -fuzz=FuzzParser -fuzztime=30s ./parser
+go test -fuzz=FuzzLexer -fuzztime=30s ./parser
+go test -fuzz=FuzzFormatterRoundTrip -fuzztime=30s ./formatter
+
+# Deep fuzzing (run before releases)
+go test -fuzz=FuzzParser -fuzztime=10m ./parser
+
+# Run fuzz corpus as regression tests
+go test ./...
+```
+
+**Fuzz Test Guidelines:**
+- All fuzz tests MUST use `defer recover()` to catch panics
+- Parser/Lexer MUST never panic on any input
+- Formatter tests round-trip property: Parse → Format → Parse
+- Seed corpus: `<package>/testdata/fuzz/<FuzzName>/` (per-package directories)
+- CI runs each fuzzer for 30 seconds
+
 ## Performance Considerations
 
 ### Memory Pooling

--- a/formatter/formatter_fuzz_test.go
+++ b/formatter/formatter_fuzz_test.go
@@ -1,0 +1,103 @@
+package formatter
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/robinvdvleuten/beancount/parser"
+)
+
+func FuzzFormatter(f *testing.F) {
+	// Seed corpus - ONLY valid beancount syntax
+	seeds := []string{
+		// Simple directives
+		"2014-01-01 open Assets:Checking USD",
+		"2014-12-31 close Assets:Checking",
+		"2014-08-09 balance Assets:Checking 100.00 USD",
+
+		// Simple transaction
+		"2014-05-05 * \"Cafe\" \"Coffee\"\n  Expenses:Food  4.50 USD\n  Assets:Cash",
+
+		// Transaction with inferred amount
+		"2014-05-06 * \"Store\"\n  Expenses:Shopping  50.00 USD\n  Assets:Checking",
+
+		// Option directive
+		"option \"title\" \"Example\"",
+
+		// Price directive
+		"2014-07-09 price HOOL 579.18 USD",
+
+		// Note directive
+		"2014-07-09 note Assets:Checking \"Called about rebate\"",
+
+		// Event directive
+		"2014-07-09 event \"location\" \"New York, USA\"",
+
+		// Pad directive
+		"2014-07-09 pad Assets:Checking Equity:Opening-Balances",
+
+		// Transaction with metadata
+		"2014-01-05 * \"Coffee\"\n  description: \"Morning coffee\"\n  Expenses:Food  5.00 USD\n  Assets:Cash",
+
+		// Transaction with tags and links
+		"2014-01-06 * \"Lunch\" #food ^receipt-001\n  Expenses:Food  15.00 USD\n  Assets:Cash",
+
+		// Multiple transactions
+		"2014-01-01 * \"A\"\n  Assets:Cash  10 USD\n  Income:Salary\n\n2014-01-02 * \"B\"\n  Expenses:Food  5 USD\n  Assets:Cash",
+	}
+
+	for _, seed := range seeds {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// CRITICAL: Must never panic
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Formatter panicked: %v\nInput: %q", r, data)
+			}
+		}()
+
+		ctx := context.Background()
+
+		// Parse original (filter invalid inputs)
+		ast1, err := parser.ParseBytes(ctx, data)
+		if err != nil {
+			return // Skip invalid inputs - formatter only works on valid syntax
+		}
+
+		// Format
+		var buf bytes.Buffer
+		fmtr := New()
+		if err := fmtr.Format(ctx, ast1, data, &buf); err != nil {
+			t.Errorf("Format failed: %v", err)
+			return
+		}
+
+		formatted := buf.Bytes()
+
+		// Property 1: Parse(Format(Parse(x))) succeeds
+		ast2, err := parser.ParseBytes(ctx, formatted)
+		if err != nil {
+			t.Errorf("Re-parsing failed: %v\nOriginal: %q\nFormatted: %q", err, data, formatted)
+			return
+		}
+
+		if ast2 == nil {
+			t.Error("Re-parsed AST is nil")
+			return
+		}
+
+		// Property 2: Format(Format(x)) == Format(x) (idempotency)
+		var buf2 bytes.Buffer
+		if err := fmtr.Format(ctx, ast2, formatted, &buf2); err != nil {
+			t.Errorf("Second format failed: %v", err)
+			return
+		}
+
+		if !bytes.Equal(buf.Bytes(), buf2.Bytes()) {
+			t.Errorf("Not idempotent:\nFirst:  %q\nSecond: %q", buf.Bytes(), buf2.Bytes())
+		}
+	})
+}

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_balance
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_balance
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-08-09 balance Assets:Checking 100.00 USD")

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_open
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_open
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-01-01 open Assets:Checking USD")

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_option
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_option
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("option \"title\" \"Example\"")

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_transaction
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_transaction
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-05-05 * \"Cafe\" \"Coffee\"\n  Expenses:Food  4.50 USD\n  Assets:Cash")

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_unicode_arabic
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_unicode_arabic
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2024-01-01 * \"مطعم\" \"غداء\"\n  Expenses:Food  50.00 SAR\n  Assets:Cash")

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_unicode_emoji
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_unicode_emoji
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2024-01-01 * \"🍕 Pizza\" \"Lunch 🍔\"\n  Expenses:Food  15.00 USD\n  Assets:Cash")

--- a/formatter/testdata/fuzz/FuzzFormatter/seed_unicode_japanese
+++ b/formatter/testdata/fuzz/FuzzFormatter/seed_unicode_japanese
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2024-01-01 * \"日本\" \"東京\"\n  Expenses:Food  1000 JPY\n  Assets:Cash")

--- a/parser/lexer_fuzz_test.go
+++ b/parser/lexer_fuzz_test.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"testing"
+)
+
+func FuzzLexer(f *testing.F) {
+	// Seed corpus with various token types
+	seeds := []string{
+		// Symbols
+		"*", "!", ":", ",", "@", "@@", "{", "}", "(", ")", "[", "]",
+
+		// Dates
+		"2014-01-01", "2023-12-31", "2024-02-29", // Leap year
+
+		// Numbers
+		"123", "123.45", "-123.45", "+123.45", "0.00", "1000000.00",
+
+		// Strings
+		"\"hello\"",
+		"\"with spaces\"",
+		"\"with \\\"quotes\\\"\"",
+		"\"empty string: \\\"\\\"\"",
+
+		// Accounts
+		"Assets:Checking",
+		"Expenses:Food:Restaurant",
+		"Liabilities:CreditCard:CapitalOne",
+		"Income:Salary:Acme",
+		"Equity:Opening-Balances",
+
+		// Tags and links
+		"#tag", "#vacation", "#2024-trip",
+		"^link", "^invoice-001", "^receipt-2024-01-15",
+
+		// Keywords
+		"txn", "balance", "open", "close", "pad", "note",
+		"document", "price", "event", "query", "custom",
+		"option", "include", "plugin",
+		"pushtag", "poptag", "pushmeta", "popmeta",
+
+		// Currencies
+		"USD", "EUR", "GBP", "JPY", "BTC", "ETH",
+
+		// Comments
+		"; comment",
+		"  ; indented comment",
+		"; comment with symbols: * @ { }",
+
+		// Whitespace
+		" ", "\t", "\n", "\r\n", "   ",
+
+		// Edge cases
+		"",          // Empty
+		"0",         // Single zero
+		".",         // Just a dot
+		"-",         // Just a minus
+		"Assets",    // Partial account
+		"Assets:",   // Account with trailing colon
+		":Checking", // Account with leading colon
+	}
+
+	for _, seed := range seeds {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// CRITICAL: Lexer must never panic on any input
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Lexer panicked on input %q: %v", data, r)
+			}
+		}()
+
+		lexer := NewLexer(data, "fuzz-test")
+		tokens := lexer.ScanAll()
+
+		// Validate invariants
+		if tokens == nil {
+			t.Error("ScanAll returned nil tokens")
+			return
+		}
+
+		if len(tokens) == 0 {
+			t.Error("ScanAll returned zero tokens (expected at least EOF)")
+			return
+		}
+
+		// Must end with EOF
+		if tokens[len(tokens)-1].Type != EOF {
+			t.Errorf("Last token must be EOF, got %v", tokens[len(tokens)-1].Type)
+		}
+
+		// All tokens must have valid positions
+		for i, tok := range tokens {
+			if tok.Line < 1 {
+				t.Errorf("Token %d has invalid line %d", i, tok.Line)
+			}
+			if tok.Column < 1 {
+				t.Errorf("Token %d has invalid column %d", i, tok.Column)
+			}
+			if tok.Start > tok.End {
+				t.Errorf("Token %d: Start=%d > End=%d", i, tok.Start, tok.End)
+			}
+			if tok.End > len(data) {
+				t.Errorf("Token %d: End=%d > data length %d", i, tok.End, len(data))
+			}
+		}
+	})
+}

--- a/parser/parser_fuzz_test.go
+++ b/parser/parser_fuzz_test.go
@@ -1,0 +1,85 @@
+package parser
+
+import (
+	"context"
+	"testing"
+)
+
+func FuzzParser(f *testing.F) {
+	// Seed corpus with representative valid inputs
+	seeds := []string{
+		// Basic directives
+		"2014-01-01 open Assets:Checking USD",
+		"2014-12-31 close Assets:Checking",
+		"2014-08-09 balance Assets:Checking 100.00 USD",
+
+		// Simple transaction
+		"2014-05-05 * \"Cafe\" \"Coffee\"\n  Expenses:Food  4.50 USD\n  Assets:Cash",
+
+		// Transaction with inferred amounts
+		"2014-05-06 * \"Store\"\n  Expenses:Shopping  50.00 USD\n  Assets:Checking",
+
+		// Options and includes
+		"option \"title\" \"Example\"",
+		"option \"operating_currency\" \"USD\"",
+		"include \"accounts.beancount\"",
+
+		// Comments and pragmas
+		"; This is a comment",
+		"pushtag #trip",
+		"poptag #trip",
+
+		// Edge cases
+		"",                   // Empty input
+		"  \n\n  \n",         // Whitespace only
+		"; Just a comment\n", // Comment only
+
+		// Metadata
+		"2014-01-01 open Assets:Checking USD\n  description: \"Primary checking account\"",
+
+		// Price directive
+		"2014-07-09 price HOOL 579.18 USD",
+
+		// Note directive
+		"2014-07-09 note Assets:Checking \"Called about rebate\"",
+
+		// Document directive
+		"2014-07-09 document Assets:Checking \"/path/to/statement.pdf\"",
+
+		// Event directive
+		"2014-07-09 event \"location\" \"New York, USA\"",
+
+		// Query directive
+		"2014-07-09 query \"cash\" \"SELECT * FROM accounts WHERE account ~ 'Cash'\"",
+
+		// Pad directive
+		"2014-07-09 pad Assets:Checking Equity:Opening-Balances",
+
+		// Custom directive
+		"2014-07-09 custom \"budget\" Expenses:Food \"monthly\" 500.00 USD",
+	}
+
+	for _, seed := range seeds {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// CRITICAL: Parser must never panic on any input
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Parser panicked on input %q: %v", data, r)
+			}
+		}()
+
+		ctx := context.Background()
+		ast, err := ParseBytes(ctx, data)
+
+		// Validate invariants
+		if err == nil {
+			if ast == nil {
+				t.Error("ParseBytes returned nil AST with nil error")
+			}
+		}
+		// If err != nil, that's expected for invalid syntax - parser handled it gracefully
+	})
+}

--- a/parser/testdata/fuzz/FuzzLexer/seed_accounts
+++ b/parser/testdata/fuzz/FuzzLexer/seed_accounts
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("Assets:Checking")

--- a/parser/testdata/fuzz/FuzzLexer/seed_currencies
+++ b/parser/testdata/fuzz/FuzzLexer/seed_currencies
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("USD")

--- a/parser/testdata/fuzz/FuzzLexer/seed_dates
+++ b/parser/testdata/fuzz/FuzzLexer/seed_dates
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-01-01")

--- a/parser/testdata/fuzz/FuzzLexer/seed_numbers
+++ b/parser/testdata/fuzz/FuzzLexer/seed_numbers
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("123.45")

--- a/parser/testdata/fuzz/FuzzLexer/seed_strings
+++ b/parser/testdata/fuzz/FuzzLexer/seed_strings
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\"hello world\"")

--- a/parser/testdata/fuzz/FuzzLexer/seed_symbols
+++ b/parser/testdata/fuzz/FuzzLexer/seed_symbols
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("*")

--- a/parser/testdata/fuzz/FuzzLexer/seed_tags
+++ b/parser/testdata/fuzz/FuzzLexer/seed_tags
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("#vacation")

--- a/parser/testdata/fuzz/FuzzLexer/seed_unicode_cjk
+++ b/parser/testdata/fuzz/FuzzLexer/seed_unicode_cjk
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\"中文字符串\"")

--- a/parser/testdata/fuzz/FuzzLexer/seed_unicode_combining
+++ b/parser/testdata/fuzz/FuzzLexer/seed_unicode_combining
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\"café\"")

--- a/parser/testdata/fuzz/FuzzLexer/seed_unicode_emoji
+++ b/parser/testdata/fuzz/FuzzLexer/seed_unicode_emoji
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\"Coffee ☕ 🥐\"")

--- a/parser/testdata/fuzz/FuzzParser/seed_accounts
+++ b/parser/testdata/fuzz/FuzzParser/seed_accounts
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("Assets:Checking")

--- a/parser/testdata/fuzz/FuzzParser/seed_balance
+++ b/parser/testdata/fuzz/FuzzParser/seed_balance
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-08-09 balance Assets:Checking 100.00 USD")

--- a/parser/testdata/fuzz/FuzzParser/seed_commodity
+++ b/parser/testdata/fuzz/FuzzParser/seed_commodity
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-01-01 commodity USD\n  name: \"US Dollar\"\n  asset-class: \"cash\"")

--- a/parser/testdata/fuzz/FuzzParser/seed_currencies
+++ b/parser/testdata/fuzz/FuzzParser/seed_currencies
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("USD")

--- a/parser/testdata/fuzz/FuzzParser/seed_dates
+++ b/parser/testdata/fuzz/FuzzParser/seed_dates
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-01-01")

--- a/parser/testdata/fuzz/FuzzParser/seed_empty
+++ b/parser/testdata/fuzz/FuzzParser/seed_empty
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("")

--- a/parser/testdata/fuzz/FuzzParser/seed_numbers
+++ b/parser/testdata/fuzz/FuzzParser/seed_numbers
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("123.45")

--- a/parser/testdata/fuzz/FuzzParser/seed_open
+++ b/parser/testdata/fuzz/FuzzParser/seed_open
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-01-01 open Assets:Checking USD")

--- a/parser/testdata/fuzz/FuzzParser/seed_plugin
+++ b/parser/testdata/fuzz/FuzzParser/seed_plugin
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("plugin \"beancount.plugins.auto_accounts\"")

--- a/parser/testdata/fuzz/FuzzParser/seed_plugin_config
+++ b/parser/testdata/fuzz/FuzzParser/seed_plugin_config
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("plugin \"beancount.plugins.check_average_cost\" \"{\\\"threshold\\\": 0.01}\"")

--- a/parser/testdata/fuzz/FuzzParser/seed_popmeta
+++ b/parser/testdata/fuzz/FuzzParser/seed_popmeta
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("popmeta location:")

--- a/parser/testdata/fuzz/FuzzParser/seed_pushmeta
+++ b/parser/testdata/fuzz/FuzzParser/seed_pushmeta
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("pushmeta location: \"New York\"")

--- a/parser/testdata/fuzz/FuzzParser/seed_strings
+++ b/parser/testdata/fuzz/FuzzParser/seed_strings
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\"hello world\"")

--- a/parser/testdata/fuzz/FuzzParser/seed_tags
+++ b/parser/testdata/fuzz/FuzzParser/seed_tags
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("#vacation")

--- a/parser/testdata/fuzz/FuzzParser/seed_transaction
+++ b/parser/testdata/fuzz/FuzzParser/seed_transaction
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2014-05-05 * \"Cafe\" \"Coffee\"\n  Expenses:Food  4.50 USD\n  Assets:Cash")

--- a/parser/testdata/fuzz/FuzzParser/seed_unicode_chinese
+++ b/parser/testdata/fuzz/FuzzParser/seed_unicode_chinese
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2024-01-01 * \"咖啡店\" \"早餐\"\n  Expenses:Food  50.00 CNY\n  Assets:Cash")

--- a/parser/testdata/fuzz/FuzzParser/seed_unicode_emoji
+++ b/parser/testdata/fuzz/FuzzParser/seed_unicode_emoji
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2024-01-01 * \"Coffee ☕\" \"Breakfast 🥐\"\n  Expenses:Food  5.00 USD\n  Assets:Cash")

--- a/parser/testdata/fuzz/FuzzParser/seed_unicode_mixed
+++ b/parser/testdata/fuzz/FuzzParser/seed_unicode_mixed
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2024-01-01 * \"Café Münch\" \"Entrée\"\n  Expenses:Food  15.00 EUR\n  Assets:Cash")

--- a/parser/testdata/fuzz/FuzzParser/seed_whitespace
+++ b/parser/testdata/fuzz/FuzzParser/seed_whitespace
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("; comment\n\n")


### PR DESCRIPTION
 Add FuzzParser, FuzzLexer, and FuzzFormatter with comprehensive seed corpus including Unicode (CJK, Arabic, emoji) and all directive types.