### PR TITLE
fix(ledger): reject mixed nil dates in GetBalanceTree

### DIFF
--- a/ledger/balance_tree_test.go
+++ b/ledger/balance_tree_test.go
@@ -259,6 +259,27 @@ func TestGetBalanceTree_InvalidDateRange(t *testing.T) {
 	assert.Contains(t, err.Error(), "after")
 }
 
+func TestGetBalanceTree_MixedNilDates(t *testing.T) {
+	l := ledger.New()
+	source := `
+2024-01-01 open Assets:Checking USD
+`
+	ctx := context.Background()
+	tree, err := parser.ParseBytes(ctx, []byte(source))
+	assert.NoError(t, err)
+	assert.NoError(t, l.Process(ctx, tree))
+
+	date, _ := ast.NewDate("2024-01-01")
+
+	// Only startDate set should return an error, not panic.
+	_, err = l.GetBalanceTree(nil, date, nil)
+	assert.Error(t, err)
+
+	// Only endDate set should return an error, not panic.
+	_, err = l.GetBalanceTree(nil, nil, date)
+	assert.Error(t, err)
+}
+
 func TestGetBalanceTree_NoTransactions(t *testing.T) {
 	l := ledger.New()
 	source := `

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -377,6 +377,9 @@ func (l *Ledger) forEachAccount(fn func(*Account) bool) {
 // aggregated bottom-up so parent nodes include the sum of all their descendants.
 func (l *Ledger) GetBalanceTree(types []ast.AccountType, startDate, endDate *ast.Date) (*BalanceTree, error) {
 	// Validate date range
+	if (startDate == nil) != (endDate == nil) {
+		return nil, fmt.Errorf("startDate and endDate must both be set or both be nil")
+	}
 	if startDate != nil && endDate != nil && startDate.After(endDate.Time) {
 		return nil, fmt.Errorf("startDate %s is after endDate %s", startDate.String(), endDate.String())
 	}


### PR DESCRIPTION
Fixes #250. `GetBalanceTree` only handles the both-nil and both-set cases; passing exactly one of startDate/endDate falls into the else branch and dereferences both pointers, so it panics with a nil pointer dereference. This adds a guard next to the existing range check that returns an error when only one date is set, and a test covering both single-date combinations.