### PR TITLE
feat(query): implement bean-query (BQL) with byte parity against beancount v2

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,3 +51,17 @@ jobs:
           fuzz-regexp: FuzzFormatter
           fuzz-minimize-time: 1m
           go-version: "1.25"
+
+  fuzz-query-parser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: jidicula/go-fuzz-action@0ec28329e946c7eea228784a83f26d73f3bfdb23
+        with:
+          packages: ./query/bql
+          fuzz-time: 30s
+          fuzz-regexp: FuzzParseQuery
+          fuzz-minimize-time: 1m
+          go-version: "1.25"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Project-specific conventions for the beancount Go implementation.
 
+**Keep this file current**: when a change alters the architecture — a new package, a changed phase pipeline, a new pattern or convention, a new compliance suite — update AGENTS.md in the same change. Stale conventions are worse than missing ones.
+
 ## Feature Evaluation: Question First, Plan Second
 
 **CRITICAL**: Before diving into implementation planning, critically evaluate whether a feature is actually needed for this project's use case.
@@ -93,6 +95,20 @@ context7_get_library_docs(context7CompatibleLibraryID: "/shopspring/decimal", to
 When changing Beancount semantics, parsing, lexing, formatting, or query behavior, validate against the relevant official tools: `bean-check`, `bean-format`, `bean-doctor`, `bean-query`. Purely internal refactors and unrelated infrastructure changes do not require an official-tool comparison.
 
 The differential suite in `cli/compliance_test.go` runs every fixture in `testdata/compliance/` through both implementations whenever `bean-check` is on PATH (`go test ./cli -run 'Compliance|Official'`). Add a fixture (`<name>.pass.beancount` / `<name>.fail.beancount`) for any semantics change; known divergences are documented in `testdata/compliance/KNOWN_GAPS.md`.
+
+**BQL / bean-query**: `cli/query_compliance_test.go` runs every `testdata/compliance/query/*.bql` fixture through both implementations (`go test ./cli -run 'QueryFixtures|OfficialQueryParity'`), comparing stdout **byte-for-byte** in text and csv. Fixture name prefixes: `err_` expects an `ERROR:` line, `numberify_` adds `-m`, `gap_` skips the parity leg (document in KNOWN_GAPS.md). Any query semantics change needs a fixture.
+
+**Pin first, implement second**: bean-query has many undocumented quirks (column naming like `sum_position`/`c42`, header truncation, padded CSV cells, implicit GROUP BY, per-currency precision). Never guess—probe the official tool with a small ledger and match the observed bytes:
+
+```bash
+# Pin behavior empirically before writing code
+bean-query testdata/compliance/query/ledger.beancount "select account, sum(position) group by account"
+bean-query -f csv ledger.beancount "select 1 + 2"   # csv shows untruncated headers
+bean-query ledger.beancount "help targets"           # official column/function reference
+
+# Diff an end-to-end query against the official tool
+diff <(go run ./cmd/beancount query f.beancount "$Q") <(bean-query f.beancount "$Q")
+```
 
 ```bash
 # Debug parser / lexer issues or inconsistencies
@@ -264,6 +280,8 @@ Telemetry naming: `package.operation` or `package.operation <context>` (e.g., `p
 | **ledger** | `decimal.Decimal` for amounts. Validation errors have `Pos`/`Directive` fields. Booking methods: `STRICT` (default), `NONE`, `FIFO`, `LIFO`, `AVERAGE`. |
 | **loader** | Recursive includes with deduplication by absolute path. Non-fatal issues go to `LoadResult.Diagnostics`. |
 | **config** | Beancount option parsing and typed processing configuration. Unknown option names are rejected (bean-check parity). |
+| **query/bql** | BQL lexer + recursive-descent parser, syntax only (mirrors parser rules: zero-copy tokens, positioned errors, fuzz test). No semantic knowledge. |
+| **query** | Parse → compile → execute → render. Columns/functions/aggregates live in registry maps (`env.go`, `functions.go`, `aggregates.go`), never switch statements. Compiler resolves names and types with bean-query-parity error messages; executor consumes the ledger-processed `*ast.AST` (interpolated amounts) and never mutates it; renderers reproduce official output byte-for-byte. |
 | **diagnostic** | Severity classification (`SeverityError`/`SeverityWarning`) for errors from loading and validation. Warnings never affect exit codes. |
 | **web** | **Local dev only**. Bind to localhost. No auth. Path traversal protection. |
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A fast, lightweight [Beancount](https://beancount.github.io/) parser and formatt
 
 [Beancount](https://beancount.github.io/) is a double-entry bookkeeping system that uses plain text files to track personal or business finances. It allows you to maintain your accounting ledger as readable text files, making it easy to version control, search, and programmatically manipulate your financial data. The Beancount file format uses a simple, human-readable syntax to record transactions, accounts, and other financial directives.
 
-This project is a Go implementation of a Beancount file parser, formatter, and validator. While the official Beancount implementation is written in Python and includes a full accounting engine with balance calculations, reports, queries, and a web interface, this Go version focuses on parsing, formatting, and ledger validation. It's designed to be fast and lightweight, making it ideal for tooling, text editors, build pipelines, or any situation where you need to validate Beancount files without the overhead of the full accounting system.
+This project is a Go implementation of a Beancount file parser, formatter, validator, and query engine. While the official Beancount implementation is written in Python and includes a full accounting engine with balance calculations, reports, queries, and a web interface, this Go version focuses on parsing, formatting, ledger validation, and BQL queries. It's designed to be fast and lightweight, making it ideal for tooling, text editors, build pipelines, or any situation where you need to work with Beancount files without the overhead of the full accounting system.
 
 ## Features
 
@@ -25,9 +25,10 @@ This implementation currently supports:
 - **Validation**: Balance checks, account lifecycle, assertions
 - **Inventory**: Lot-based tracking with cost basis (FIFO/LIFO)
 - **Includes**: Recursive loading of modular Beancount files
+- **Queries**: The Beancount Query Language (BQL), compatible with `bean-query`
 - **CLI Interface**: Simple command-line tools for common operations
 
-**Note**: This implementation includes ledger validation with transaction balancing, account management, and inventory tracking. It does not include reporting, queries, or a web interface like the official Python implementation.
+**Note**: This implementation includes ledger validation with transaction balancing, account management, inventory tracking, and BQL queries. It does not include reporting or plugins like the official Python implementation.
 
 ## Compatibility
 
@@ -114,6 +115,45 @@ Or read from stdin (omit filename or use `-`):
 ```sh
 echo "2024-01-01 open Assets:Checking USD" | beancount format
 ```
+
+### Query a Beancount file
+
+Run [Beancount Query Language](https://beancount.github.io/docs/beancount_query_language.html) (BQL) queries against a ledger, just like `bean-query`:
+
+```sh
+beancount query example.beancount "SELECT account, sum(position) GROUP BY account ORDER BY account"
+```
+
+```
+        account                sum_position
+----------------------- --------------------------
+Assets:Checking          3495.50 USD
+Assets:Invest              10    HOOL {500.00 USD}
+Equity:Opening-Balances -1000.00 USD
+...
+```
+
+The full SELECT grammar is supported (FROM with OPEN/CLOSE/CLEAR summarization, WHERE, GROUP BY, ORDER BY, LIMIT, DISTINCT), along with the aggregate functions, the simple-function library, and the `BALANCES`, `JOURNAL`, and `PRINT` shortcut statements:
+
+```sh
+# Balances per account, at cost
+beancount query example.beancount "BALANCES AT cost"
+
+# A running journal for accounts matching a regex
+beancount query example.beancount 'JOURNAL "Checking"'
+
+# CSV output, with amounts split into per-currency number columns
+beancount query -f csv -m example.beancount "SELECT account, sum(position) GROUP BY account"
+```
+
+Omit the query to start an interactive shell, or pipe one in:
+
+```sh
+beancount query example.beancount
+echo "SELECT payee, narration WHERE 'trip' IN tags" | beancount query example.beancount
+```
+
+Output is byte-for-byte compatible with `bean-query` from beancount v2; the compliance suite in `testdata/compliance/query` enforces this against the official tool.
 
 ### Telemetry
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -16,5 +16,6 @@ type Commands struct {
 	Check  CheckCmd  `cmd:"" help:"Parse, check and realize a beancount input file."`
 	Doctor DoctorCmd `cmd:"" help:"Doctor utilities for debugging beancount files."`
 	Format FormatCmd `cmd:"" help:"Format a beancount file to align numbers and currencies."`
+	Query  QueryCmd  `cmd:"" help:"Run a BQL query against a beancount input file."`
 	Web    WebCmd    `cmd:"" help:"Start a web server."`
 }

--- a/cli/query.go
+++ b/cli/query.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	stdErrors "errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/config"
+	"github.com/robinvdvleuten/beancount/ledger"
+	"github.com/robinvdvleuten/beancount/loader"
+	"github.com/robinvdvleuten/beancount/query"
+	"github.com/robinvdvleuten/beancount/query/bql"
+)
+
+type QueryCmd struct {
+	Format    string      `short:"f" default:"text" enum:"text,csv" help:"Output format: text or csv."`
+	Output    string      `short:"o" placeholder:"FILE" help:"Write output to FILE instead of stdout."`
+	Numberify bool        `short:"m" help:"Split amounts into per-currency number columns (csv only)."`
+	File      FileOrStdin `help:"Beancount input filename (use '-' for stdin)." arg:""`
+	Query     []string    `help:"BQL query to run." arg:"" optional:""`
+}
+
+func (cmd *QueryCmd) Run(ctx *kong.Context, globals *Globals) error {
+	if err := cmd.File.EnsureContents(); err != nil {
+		return err
+	}
+	queryText := strings.TrimSpace(strings.Join(cmd.Query, " "))
+
+	runCtx := context.Background()
+
+	sourceContent, err := cmd.File.GetSourceContent()
+	if err != nil {
+		return fmt.Errorf("failed to read file for error context: %w", err)
+	}
+
+	ldr := loader.New(loader.WithFollowIncludes(), loader.WithDocumentsDiscovery())
+	loadResult, err := cmd.File.LoadResult(runCtx, ldr)
+	if err != nil {
+		renderer := NewErrorRenderer(sourceContent)
+		_, _ = fmt.Fprintln(ctx.Stderr, renderer.Render(err))
+		return NewCommandError(1)
+	}
+	tree := loadResult.AST
+
+	// Like bean-query, validation problems are reported but do not prevent
+	// querying the loadable portion of the ledger.
+	var validationErrors *ledger.ValidationErrors
+	l := ledger.New()
+	if err := l.Process(runCtx, tree); err != nil {
+		if stdErrors.As(err, &validationErrors) {
+			renderer := NewErrorRenderer(sourceContent)
+			_, _ = fmt.Fprintln(ctx.Stderr, renderer.RenderAll(validationErrors.Errors))
+		} else {
+			return err
+		}
+	}
+
+	cfg, err := config.FromAST(tree)
+	if err != nil {
+		return err
+	}
+
+	qctx := &query.Context{Ledger: l, Config: cfg}
+
+	// Without a query argument, a terminal gets the interactive shell and
+	// piped stdin is read as a single query, like bean-query.
+	if queryText == "" {
+		if cmd.File.Filename != "<stdin>" && term.IsTerminal(int(os.Stdin.Fd())) {
+			return runShell(runCtx, qctx, tree, cmd.Format, cmd.Numberify, os.Stdin, ctx.Stdout, validationErrors, sourceContent)
+		}
+		piped, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("failed to read query from stdin: %w", err)
+		}
+		queryText = strings.TrimSpace(string(piped))
+		if queryText == "" {
+			return fmt.Errorf("no query given")
+		}
+	}
+
+	out := io.Writer(ctx.Stdout)
+	if cmd.Output != "" {
+		file, err := os.Create(cmd.Output)
+		if err != nil {
+			return fmt.Errorf("failed to create output file %s: %w", cmd.Output, err)
+		}
+		out = file
+		if runErr := runQuery(runCtx, qctx, tree, queryText, cmd.Format, cmd.Numberify, out); runErr != nil {
+			_ = file.Close()
+			return runErr
+		}
+		return file.Close()
+	}
+
+	return runQuery(runCtx, qctx, tree, queryText, cmd.Format, cmd.Numberify, out)
+}
+
+// runShell is the interactive query REPL: one query per line, with help,
+// errors, and exit commands.
+func runShell(ctx context.Context, qctx *query.Context, tree *ast.AST, format string, numberify bool, in io.Reader, out io.Writer, validationErrors *ledger.ValidationErrors, sourceContent []byte) error {
+	printShellBanner(out, tree)
+
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for {
+		_, _ = fmt.Fprint(out, "beancount> ")
+		if !scanner.Scan() {
+			_, _ = fmt.Fprintln(out)
+			return scanner.Err()
+		}
+		line := strings.TrimSpace(strings.TrimSuffix(scanner.Text(), ";"))
+		switch strings.ToLower(line) {
+		case "":
+			continue
+		case "exit", "quit":
+			return nil
+		case "help":
+			_, _ = fmt.Fprintln(out, "Enter a BQL query (SELECT, BALANCES, JOURNAL, PRINT).")
+			_, _ = fmt.Fprintln(out, "Commands: errors (show ledger errors), exit or quit (leave the shell).")
+			continue
+		case "errors":
+			if validationErrors == nil || len(validationErrors.Errors) == 0 {
+				_, _ = fmt.Fprintln(out, "(no errors)")
+				continue
+			}
+			renderer := NewErrorRenderer(sourceContent)
+			_, _ = fmt.Fprintln(out, renderer.RenderAll(validationErrors.Errors))
+			continue
+		}
+		if err := runQuery(ctx, qctx, tree, line, format, numberify, out); err != nil {
+			return err
+		}
+	}
+}
+
+// printShellBanner reports the ledger title and directive counts, following
+// the official shell greeting.
+func printShellBanner(out io.Writer, tree *ast.AST) {
+	title := ""
+	for _, option := range tree.Options {
+		if option.Name.String() == "title" {
+			title = option.Value.String()
+		}
+	}
+	if title != "" {
+		_, _ = fmt.Fprintf(out, "Input file: %q\n", title)
+	}
+	transactions, postings := 0, 0
+	for _, entry := range tree.Directives {
+		if txn, ok := entry.(*ast.Transaction); ok {
+			transactions++
+			postings += len(txn.Postings)
+		}
+	}
+	_, _ = fmt.Fprintf(out, "Ready with %d directives (%d postings in %d transactions).\n",
+		len(tree.Directives), postings, transactions)
+}
+
+// runQuery parses, compiles, executes, and renders one BQL query. Query
+// errors print as "ERROR: ..." on the output stream with a zero exit status,
+// matching the official bean-query tool.
+func runQuery(ctx context.Context, qctx *query.Context, tree *ast.AST, queryText, format string, numberify bool, out io.Writer) error {
+	stmt, err := bql.Parse(queryText)
+	if err != nil {
+		return printQueryError(out, err)
+	}
+
+	if print, ok := stmt.(*bql.Print); ok {
+		compiled, err := query.CompilePrint(qctx, print)
+		if err != nil {
+			return printQueryError(out, err)
+		}
+		if err := query.ExecutePrint(ctx, qctx, tree, compiled, out); err != nil {
+			return printQueryError(out, err)
+		}
+		return nil
+	}
+
+	compiled, err := query.Compile(qctx, stmt)
+	if err != nil {
+		return printQueryError(out, err)
+	}
+	result, err := query.Execute(ctx, qctx, tree, compiled)
+	if err != nil {
+		return printQueryError(out, err)
+	}
+
+	switch format {
+	case "csv":
+		return query.RenderCSV(result, out, numberify)
+	default:
+		return query.RenderText(result, out)
+	}
+}
+
+func printQueryError(out io.Writer, err error) error {
+	message := err.Error()
+	// Positioned parse errors render as plain messages here; the position
+	// prefix only makes sense for multi-line shell input.
+	var parseErr *bql.ParseError
+	if stdErrors.As(err, &parseErr) {
+		message = fmt.Sprintf("Syntax error: %s", parseErr.Message)
+	}
+	_, printErr := fmt.Fprintf(out, "ERROR: %s\n", message)
+	return printErr
+}

--- a/cli/query_compliance_test.go
+++ b/cli/query_compliance_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"context"
+	stdErrors "errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/config"
+	"github.com/robinvdvleuten/beancount/ledger"
+	"github.com/robinvdvleuten/beancount/loader"
+	"github.com/robinvdvleuten/beancount/query"
+)
+
+const queryComplianceDir = "../testdata/compliance/query"
+
+// queryFixture is a .bql file run against the shared ledger.beancount (or a
+// same-named .beancount override). A gap_ prefix marks a known divergence
+// from the official tool, documented in KNOWN_GAPS.md; gap fixtures are
+// skipped by the parity leg. A numberify_ prefix runs the query with -m.
+type queryFixture struct {
+	name      string
+	query     string
+	ledger    string
+	numberify bool
+	knownGap  bool
+}
+
+func loadQueryFixtures(t *testing.T) []queryFixture {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(queryComplianceDir, "*.bql"))
+	assert.NoError(t, err)
+	assert.True(t, len(paths) > 0, "no query fixtures found in %s", queryComplianceDir)
+
+	var fixtures []queryFixture
+	for _, path := range paths {
+		name := strings.TrimSuffix(filepath.Base(path), ".bql")
+		source, err := os.ReadFile(path)
+		assert.NoError(t, err)
+
+		ledgerPath := filepath.Join(queryComplianceDir, name+".beancount")
+		if _, err := os.Stat(ledgerPath); err != nil {
+			ledgerPath = filepath.Join(queryComplianceDir, "ledger.beancount")
+		}
+
+		fixtures = append(fixtures, queryFixture{
+			name:      name,
+			query:     strings.TrimSpace(string(source)),
+			ledger:    ledgerPath,
+			numberify: strings.HasPrefix(name, "numberify_"),
+			knownGap:  strings.HasPrefix(name, "gap_"),
+		})
+	}
+	return fixtures
+}
+
+// runOurQuery executes a fixture through the same pipeline as the query
+// command and returns what would be written to stdout.
+func runOurQuery(t *testing.T, fixture queryFixture, format string, numberify bool) string {
+	t.Helper()
+
+	ctx := context.Background()
+	ldr := loader.New(loader.WithFollowIncludes(), loader.WithDocumentsDiscovery())
+	result, err := ldr.Load(ctx, fixture.ledger)
+	assert.NoError(t, err)
+
+	l := ledger.New()
+	if err := l.Process(ctx, result.AST); err != nil {
+		var validationErrors *ledger.ValidationErrors
+		assert.True(t, stdErrors.As(err, &validationErrors), "unexpected process error: %v", err)
+	}
+
+	cfg, err := config.FromAST(result.AST)
+	assert.NoError(t, err)
+
+	var out strings.Builder
+	qctx := &query.Context{Ledger: l, Config: cfg}
+	assert.NoError(t, runQuery(ctx, qctx, result.AST, fixture.query, format, numberify, &out))
+	return out.String()
+}
+
+// TestQueryFixtures runs every fixture through our engine in both formats,
+// so the suite exercises the fixtures even without bean-query installed.
+// Error fixtures (err_ prefix) must produce an ERROR: line.
+func TestQueryFixtures(t *testing.T) {
+	for _, fixture := range loadQueryFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			for _, format := range []string{"text", "csv"} {
+				output := runOurQuery(t, fixture, format, fixture.numberify)
+				if strings.HasPrefix(fixture.name, "err_") {
+					assert.True(t, strings.HasPrefix(output, "ERROR: "), "expected an error, got: %s", output)
+				} else {
+					assert.False(t, strings.HasPrefix(output, "ERROR: "), "unexpected error: %s", output)
+				}
+			}
+		})
+	}
+}
+
+// TestOfficialQueryParity compares our output byte-for-byte with bean-query
+// in both text and csv formats. Runs whenever bean-query 2.x is installed.
+func TestOfficialQueryParity(t *testing.T) {
+	if _, err := exec.LookPath("bean-query"); err != nil {
+		t.Skip("bean-query not found in PATH; install beancount 2.x to run the query parity suite")
+	}
+
+	version, err := exec.Command("bean-query", "--version").CombinedOutput()
+	assert.NoError(t, err)
+	assert.Contains(t, string(version), "2.", "query parity suite targets beancount v2")
+
+	for _, fixture := range loadQueryFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			if fixture.knownGap {
+				t.Skipf("known gap, see %s", filepath.Join("..", "testdata", "compliance", "KNOWN_GAPS.md"))
+			}
+
+			for _, format := range []string{"text", "csv"} {
+				args := []string{"-f", format}
+				if fixture.numberify {
+					args = append(args, "-m")
+				}
+				args = append(args, fixture.ledger, fixture.query)
+
+				// bean-query prints query errors to stdout and exits zero,
+				// so Output() captures everything we compare against.
+				official, err := exec.Command("bean-query", args...).Output()
+				assert.NoError(t, err)
+
+				ours := runOurQuery(t, fixture, format, fixture.numberify)
+				assert.Equal(t, string(official), ours, "format %s, query: %s", format, fixture.query)
+			}
+		})
+	}
+}

--- a/cli/query_test.go
+++ b/cli/query_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/config"
+	"github.com/robinvdvleuten/beancount/ledger"
+	"github.com/robinvdvleuten/beancount/loader"
+	"github.com/robinvdvleuten/beancount/query"
+)
+
+func TestQueryShell(t *testing.T) {
+	ctx := context.Background()
+	ldr := loader.New(loader.WithFollowIncludes())
+	result, err := ldr.Load(ctx, "../testdata/compliance/query/ledger.beancount")
+	assert.NoError(t, err)
+
+	l := ledger.New()
+	assert.NoError(t, l.Process(ctx, result.AST))
+	cfg, err := config.FromAST(result.AST)
+	assert.NoError(t, err)
+	qctx := &query.Context{Ledger: l, Config: cfg}
+
+	in := strings.NewReader("help\nerrors\nselect count(date);\nbogus query\nexit\n")
+	var out strings.Builder
+	assert.NoError(t, runShell(ctx, qctx, result.AST, "text", false, in, &out, nil, nil))
+
+	output := out.String()
+	assert.Contains(t, output, `Input file: "Query Compliance Ledger"`)
+	assert.Contains(t, output, "Ready with 26 directives (22 postings in 10 transactions).")
+	assert.Contains(t, output, "beancount> ")
+	assert.Contains(t, output, "Commands: errors")
+	assert.Contains(t, output, "(no errors)")
+	assert.Contains(t, output, "22")         // count(date) result
+	assert.Contains(t, output, "ERROR: ")    // bogus query reports, shell continues
+	assert.NotContains(t, output, "bogus\n") // and does not echo the input
+}
+
+func TestQueryShellEOF(t *testing.T) {
+	ctx := context.Background()
+	ldr := loader.New(loader.WithFollowIncludes())
+	result, err := ldr.Load(ctx, "../testdata/compliance/query/ledger.beancount")
+	assert.NoError(t, err)
+
+	l := ledger.New()
+	assert.NoError(t, l.Process(ctx, result.AST))
+	cfg, err := config.FromAST(result.AST)
+	assert.NoError(t, err)
+
+	var out strings.Builder
+	assert.NoError(t, runShell(ctx, &query.Context{Ledger: l, Config: cfg}, result.AST,
+		"text", false, strings.NewReader(""), &out, nil, nil))
+}

--- a/ledger/amount.go
+++ b/ledger/amount.go
@@ -34,6 +34,13 @@ func MustParseAmount(amount *ast.Amount) decimal.Decimal {
 	return d
 }
 
+// formatInferredNumber renders an interpolated number preserving its decimal
+// scale (decimal.String trims trailing zeros, so a -4.50 residual would
+// otherwise display as -4.5, diverging from official beancount).
+func formatInferredNumber(d decimal.Decimal) string {
+	return d.StringFixed(max(-d.Exponent(), 0))
+}
+
 // ToleranceConfig aliases the shared tolerance configuration.
 type ToleranceConfig = sharedconfig.Tolerance
 

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -527,7 +527,7 @@ func (v *validator) calculateBalance(txn *ast.Transaction) (*TransactionDelta, *
 			for currency, residual := range balance {
 				needed := residual.Neg()
 				delta.InferredAmounts[posting] = &ast.Amount{
-					Value:    needed.String(),
+					Value:    formatInferredNumber(needed),
 					Currency: currency,
 				}
 				// Update balance to reflect the inferred amount
@@ -549,7 +549,7 @@ func (v *validator) calculateBalance(txn *ast.Transaction) (*TransactionDelta, *
 		currency := posting.Amount.Currency
 		needed := balance[currency].Neg()
 		delta.InferredAmounts[posting] = &ast.Amount{
-			Value:    needed.String(),
+			Value:    formatInferredNumber(needed),
 			Currency: currency,
 		}
 		balance[currency] = balance[currency].Add(needed)

--- a/query/aggregates.go
+++ b/query/aggregates.go
@@ -1,0 +1,156 @@
+package query
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+// accumulator collects one aggregate function's values over the rows of a
+// group and produces the final value.
+type accumulator interface {
+	update(v any)
+	finalize() any
+}
+
+// aggDef declares an aggregate function: the result type it produces for a
+// given argument type (ok=false when the argument type is unsupported) and a
+// factory for per-group accumulators.
+type aggDef struct {
+	resultType func(arg DType) (DType, bool)
+	new        func(arg DType) accumulator
+}
+
+// aggregates is the registry of aggregate functions, matching the official
+// bean-query environment.
+var aggregates = map[string]*aggDef{
+	"count": {
+		resultType: func(DType) (DType, bool) { return TInt, true },
+		new:        func(DType) accumulator { return &countAcc{} },
+	},
+	"first": {
+		resultType: func(arg DType) (DType, bool) { return arg, true },
+		new:        func(DType) accumulator { return &firstAcc{} },
+	},
+	"last": {
+		resultType: func(arg DType) (DType, bool) { return arg, true },
+		new:        func(DType) accumulator { return &lastAcc{} },
+	},
+	"min": {
+		resultType: func(arg DType) (DType, bool) { return arg, true },
+		new:        func(DType) accumulator { return &minMaxAcc{keepMin: true} },
+	},
+	"max": {
+		resultType: func(arg DType) (DType, bool) { return arg, true },
+		new:        func(DType) accumulator { return &minMaxAcc{} },
+	},
+	"sum": {
+		resultType: func(arg DType) (DType, bool) {
+			switch arg {
+			case TInt:
+				return TInt, true
+			case TDecimal, TAny:
+				return TDecimal, true
+			case TAmount, TPosition, TInventory:
+				return TInventory, true
+			}
+			return TAny, false
+		},
+		new: func(arg DType) accumulator {
+			switch arg {
+			case TInt:
+				return &sumIntAcc{}
+			case TAmount, TPosition, TInventory:
+				return &sumInventoryAcc{inv: NewInventory()}
+			default:
+				return &sumDecimalAcc{}
+			}
+		},
+	},
+}
+
+// countAcc counts rows, including NULL values, matching Python's len().
+type countAcc struct {
+	n int64
+}
+
+func (a *countAcc) update(any)    { a.n++ }
+func (a *countAcc) finalize() any { return a.n }
+
+type firstAcc struct {
+	value any
+	seen  bool
+}
+
+func (a *firstAcc) update(v any) {
+	if !a.seen {
+		a.value, a.seen = v, true
+	}
+}
+func (a *firstAcc) finalize() any { return a.value }
+
+type lastAcc struct {
+	value any
+}
+
+func (a *lastAcc) update(v any)  { a.value = v }
+func (a *lastAcc) finalize() any { return a.value }
+
+type minMaxAcc struct {
+	keepMin bool
+	value   any
+	seen    bool
+}
+
+func (a *minMaxAcc) update(v any) {
+	if v == nil {
+		return
+	}
+	if !a.seen {
+		a.value, a.seen = v, true
+		return
+	}
+	cmp := compareValues(v, a.value)
+	if (a.keepMin && cmp < 0) || (!a.keepMin && cmp > 0) {
+		a.value = v
+	}
+}
+func (a *minMaxAcc) finalize() any { return a.value }
+
+type sumIntAcc struct {
+	total int64
+}
+
+func (a *sumIntAcc) update(v any) {
+	if n, ok := v.(int64); ok {
+		a.total += n
+	}
+}
+func (a *sumIntAcc) finalize() any { return a.total }
+
+type sumDecimalAcc struct {
+	total decimal.Decimal
+}
+
+func (a *sumDecimalAcc) update(v any) {
+	if d, ok := asDecimal(v); ok {
+		a.total = a.total.Add(d)
+	}
+}
+func (a *sumDecimalAcc) finalize() any { return a.total }
+
+// sumInventoryAcc sums amounts, positions, or inventories into an Inventory,
+// matching the official SUM aggregates.
+type sumInventoryAcc struct {
+	inv *Inventory
+}
+
+func (a *sumInventoryAcc) update(v any) {
+	switch val := v.(type) {
+	case *Amount:
+		a.inv.AddAmount(val)
+	case *Position:
+		a.inv.AddPosition(val)
+	case *Inventory:
+		a.inv.AddInventory(val)
+	}
+}
+func (a *sumInventoryAcc) finalize() any { return a.inv }

--- a/query/bql/ast.go
+++ b/query/bql/ast.go
@@ -1,0 +1,180 @@
+// Package bql provides the lexer, AST, and parser for the Beancount Query
+// Language (BQL) as implemented by the official bean-query tool. The parser
+// handles syntax only; name resolution and type checking live in the query
+// package's compiler.
+package bql
+
+import (
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/shopspring/decimal"
+)
+
+// Node is implemented by all BQL AST nodes.
+type Node interface {
+	Pos() ast.Position
+}
+
+// position provides the Pos accessor for embedding in AST nodes.
+type position struct {
+	pos ast.Position
+}
+
+func (p position) Pos() ast.Position { return p.pos }
+
+// Statement is a complete BQL statement.
+type Statement interface {
+	Node
+	stmt()
+}
+
+// Select is a SELECT statement, the core BQL query form.
+type Select struct {
+	position
+	Distinct bool
+	Wildcard bool     // SELECT *
+	Targets  []Target // empty when Wildcard
+	From     *From
+	Where    Expr
+	GroupBy  []Expr // column names, aliases, or 1-based integer indices
+	OrderBy  []Expr
+	// OrderDesc applies to the whole ORDER BY list; the official grammar
+	// accepts a single trailing ASC or DESC, not one per term.
+	OrderDesc bool
+	PivotBy   []Expr
+	Limit     *int64
+}
+
+func (*Select) stmt() {}
+
+// Target is a single SELECT target: an expression with an optional alias.
+type Target struct {
+	Expr Expr
+	As   string
+}
+
+// From is the FROM clause: an optional entry-level filter expression plus
+// optional summarization transforms.
+type From struct {
+	position
+	Expr    Expr
+	OpenOn  *ast.Date
+	Close   bool // bare CLOSE, or CLOSE ON when CloseOn is set
+	CloseOn *ast.Date
+	Clear   bool
+}
+
+// Balances is the BALANCES shortcut statement.
+type Balances struct {
+	position
+	Summary string // AT <function>, empty if absent
+	From    *From
+}
+
+func (*Balances) stmt() {}
+
+// Journal is the JOURNAL shortcut statement.
+type Journal struct {
+	position
+	Account string // optional account regex, empty if absent
+	Summary string // AT <function>, empty if absent
+	From    *From
+}
+
+func (*Journal) stmt() {}
+
+// Print is the PRINT statement, rendering matching directives as beancount text.
+type Print struct {
+	position
+	From *From
+}
+
+func (*Print) stmt() {}
+
+// Expr is a BQL expression node.
+type Expr interface {
+	Node
+	expr()
+}
+
+// Ident is a column reference.
+type Ident struct {
+	position
+	Name string
+}
+
+func (*Ident) expr() {}
+
+// Call is a function call.
+type Call struct {
+	position
+	Func string
+	Args []Expr
+}
+
+func (*Call) expr() {}
+
+// Unary is a unary operation. Op is MINUS, PLUS, or NOT.
+type Unary struct {
+	position
+	Op TokenType
+	X  Expr
+}
+
+func (*Unary) expr() {}
+
+// Binary is a binary operation. Op is one of AND, OR, EQ, NE, LT, LTE, GT,
+// GTE, TILDE, IN, PLUS, MINUS, ASTERISK, SLASH.
+type Binary struct {
+	position
+	Op   TokenType
+	L, R Expr
+}
+
+func (*Binary) expr() {}
+
+// Str is a string literal.
+type Str struct {
+	position
+	Value string
+}
+
+func (*Str) expr() {}
+
+// Int is an integer literal.
+type Int struct {
+	position
+	Value int64
+}
+
+func (*Int) expr() {}
+
+// Dec is a decimal literal.
+type Dec struct {
+	position
+	Value decimal.Decimal
+}
+
+func (*Dec) expr() {}
+
+// DateLit is a date literal (YYYY-MM-DD).
+type DateLit struct {
+	position
+	Value *ast.Date
+}
+
+func (*DateLit) expr() {}
+
+// Bool is a TRUE or FALSE literal.
+type Bool struct {
+	position
+	Value bool
+}
+
+func (*Bool) expr() {}
+
+// Null is the NULL literal.
+type Null struct {
+	position
+}
+
+func (*Null) expr() {}

--- a/query/bql/errors.go
+++ b/query/bql/errors.go
@@ -1,0 +1,23 @@
+package bql
+
+import (
+	"fmt"
+
+	"github.com/robinvdvleuten/beancount/ast"
+)
+
+// ParseError represents an error that occurred while parsing a BQL query.
+type ParseError struct {
+	Pos     ast.Position
+	Message string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Pos, e.Message)
+}
+
+// GetPosition implements the positioned-error interface used by the CLI
+// error renderer.
+func (e *ParseError) GetPosition() ast.Position {
+	return e.Pos
+}

--- a/query/bql/lexer.go
+++ b/query/bql/lexer.go
@@ -1,0 +1,177 @@
+package bql
+
+import (
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/ast"
+)
+
+// Lexer scans BQL query text into tokens. Whitespace (including newlines) is
+// insignificant; queries may span multiple lines in the interactive shell.
+type Lexer struct {
+	source []byte
+	pos    int
+	line   int
+	col    int
+}
+
+// NewLexer creates a lexer over the given query source.
+func NewLexer(source []byte) *Lexer {
+	return &Lexer{source: source, line: 1, col: 1}
+}
+
+// Next scans and returns the next token, or an EOF token at end of input.
+func (l *Lexer) Next() Token {
+	l.skipWhitespace()
+
+	if l.pos >= len(l.source) {
+		return Token{Type: EOF, Start: l.pos, End: l.pos, Line: l.line, Column: l.col}
+	}
+
+	start, line, col := l.pos, l.line, l.col
+	c := l.source[l.pos]
+
+	switch {
+	case isIdentStart(c):
+		return l.scanIdent(start, line, col)
+	case isDigit(c):
+		return l.scanNumberOrDate(start, line, col)
+	case c == '"' || c == '\'':
+		return l.scanString(c, start, line, col)
+	}
+
+	l.advance()
+	tok := func(t TokenType) Token {
+		return Token{Type: t, Start: start, End: l.pos, Line: line, Column: col}
+	}
+
+	switch c {
+	case '(':
+		return tok(LPAREN)
+	case ')':
+		return tok(RPAREN)
+	case ',':
+		return tok(COMMA)
+	case ';':
+		return tok(SEMICOLON)
+	case '*':
+		return tok(ASTERISK)
+	case '/':
+		return tok(SLASH)
+	case '+':
+		return tok(PLUS)
+	case '-':
+		return tok(MINUS)
+	case '~':
+		return tok(TILDE)
+	case '=':
+		return tok(EQ)
+	case '!':
+		if l.pos < len(l.source) && l.source[l.pos] == '=' {
+			l.advance()
+			return tok(NE)
+		}
+		return tok(ILLEGAL)
+	case '<':
+		if l.pos < len(l.source) && l.source[l.pos] == '=' {
+			l.advance()
+			return tok(LTE)
+		}
+		return tok(LT)
+	case '>':
+		if l.pos < len(l.source) && l.source[l.pos] == '=' {
+			l.advance()
+			return tok(GTE)
+		}
+		return tok(GT)
+	}
+
+	return tok(ILLEGAL)
+}
+
+func (l *Lexer) scanIdent(start, line, col int) Token {
+	for l.pos < len(l.source) && isIdentPart(l.source[l.pos]) {
+		l.advance()
+	}
+	text := string(l.source[start:l.pos])
+	typ := IDENT
+	if kw, ok := keywords[strings.ToUpper(text)]; ok {
+		typ = kw
+	}
+	return Token{Type: typ, Start: start, End: l.pos, Line: line, Column: col}
+}
+
+// scanNumberOrDate scans an INTEGER, DECIMAL, or DATE token. Date literals
+// are detected by shape (YYYY-MM-DD); value validation happens in the parser
+// so invalid dates report a positioned parse error, not a lexer error.
+func (l *Lexer) scanNumberOrDate(start, line, col int) Token {
+	if start+10 <= len(l.source) &&
+		ast.IsDateLiteralShape(l.source[start:start+10]) &&
+		l.source[start+4] == '-' {
+		for l.pos < start+10 {
+			l.advance()
+		}
+		return Token{Type: DATE, Start: start, End: l.pos, Line: line, Column: col}
+	}
+
+	for l.pos < len(l.source) && isDigit(l.source[l.pos]) {
+		l.advance()
+	}
+	typ := INTEGER
+	if l.pos < len(l.source) && l.source[l.pos] == '.' {
+		typ = DECIMAL
+		l.advance()
+		for l.pos < len(l.source) && isDigit(l.source[l.pos]) {
+			l.advance()
+		}
+	}
+	return Token{Type: typ, Start: start, End: l.pos, Line: line, Column: col}
+}
+
+// scanString scans a quoted string literal. Both single and double quotes are
+// accepted, without escape sequences, matching the official BQL lexer.
+func (l *Lexer) scanString(quote byte, start, line, col int) Token {
+	l.advance() // opening quote
+	for l.pos < len(l.source) && l.source[l.pos] != quote {
+		l.advance()
+	}
+	if l.pos >= len(l.source) {
+		// Unterminated string; report the whole remainder as illegal.
+		return Token{Type: ILLEGAL, Start: start, End: l.pos, Line: line, Column: col}
+	}
+	l.advance() // closing quote
+	return Token{Type: STRING, Start: start, End: l.pos, Line: line, Column: col}
+}
+
+func (l *Lexer) skipWhitespace() {
+	for l.pos < len(l.source) {
+		switch l.source[l.pos] {
+		case ' ', '\t', '\r', '\n':
+			l.advance()
+		default:
+			return
+		}
+	}
+}
+
+func (l *Lexer) advance() {
+	if l.source[l.pos] == '\n' {
+		l.line++
+		l.col = 1
+	} else {
+		l.col++
+	}
+	l.pos++
+}
+
+func isIdentStart(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_'
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || isDigit(c)
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}

--- a/query/bql/parser.go
+++ b/query/bql/parser.go
@@ -1,0 +1,586 @@
+package bql
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/shopspring/decimal"
+)
+
+// queryFilename is the filename used in positions for parsed query strings.
+const queryFilename = "<query>"
+
+// Parse parses a BQL statement from the given query string.
+func Parse(query string) (Statement, error) {
+	return ParseBytes([]byte(query))
+}
+
+// ParseBytes parses a BQL statement from the given query source.
+func ParseBytes(source []byte) (Statement, error) {
+	p := newParser(source)
+	stmt, err := p.parseStatement()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type == SEMICOLON {
+		p.next()
+	}
+	if p.cur.Type != EOF {
+		return nil, p.errorf(p.cur, "unexpected %s", p.describe(p.cur))
+	}
+	return stmt, nil
+}
+
+// Parser is a recursive-descent parser for BQL statements.
+type parser struct {
+	source []byte
+	lexer  *Lexer
+	cur    Token
+}
+
+func newParser(source []byte) *parser {
+	p := &parser{source: source, lexer: NewLexer(source)}
+	p.next()
+	return p
+}
+
+func (p *parser) next() {
+	p.cur = p.lexer.Next()
+}
+
+// expect consumes the current token if it has the given type, or fails with a
+// positioned error naming what was expected.
+func (p *parser) expect(t TokenType, context string) (Token, error) {
+	if p.cur.Type != t {
+		return Token{}, p.errorf(p.cur, "expected %s in %s, found %s", t, context, p.describe(p.cur))
+	}
+	tok := p.cur
+	p.next()
+	return tok, nil
+}
+
+// accept consumes the current token if it has the given type.
+func (p *parser) accept(t TokenType) bool {
+	if p.cur.Type == t {
+		p.next()
+		return true
+	}
+	return false
+}
+
+func (p *parser) pos(tok Token) ast.Position {
+	return ast.Position{Filename: queryFilename, Offset: tok.Start, Line: tok.Line, Column: tok.Column}
+}
+
+func (p *parser) errorf(tok Token, format string, args ...any) *ParseError {
+	return &ParseError{
+		Pos:     p.pos(tok),
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func (p *parser) describe(tok Token) string {
+	switch tok.Type {
+	case EOF:
+		return "end of query"
+	case IDENT, STRING, INTEGER, DECIMAL, DATE, ILLEGAL:
+		return fmt.Sprintf("%s %q", strings.ToLower(tok.Type.String()), tok.String(p.source))
+	default:
+		return fmt.Sprintf("%q", tok.String(p.source))
+	}
+}
+
+func (p *parser) parseStatement() (Statement, error) {
+	switch p.cur.Type {
+	case SELECT:
+		return p.parseSelect()
+	case BALANCES:
+		return p.parseBalances()
+	case JOURNAL:
+		return p.parseJournal()
+	case PRINT:
+		return p.parsePrint()
+	default:
+		return nil, p.errorf(p.cur, "expected SELECT, BALANCES, JOURNAL or PRINT, found %s", p.describe(p.cur))
+	}
+}
+
+func (p *parser) parseSelect() (*Select, error) {
+	tok := p.cur
+	p.next() // SELECT
+
+	sel := &Select{position: position{p.pos(tok)}}
+	sel.Distinct = p.accept(DISTINCT)
+
+	if p.accept(ASTERISK) {
+		sel.Wildcard = true
+	} else {
+		for {
+			target, err := p.parseTarget()
+			if err != nil {
+				return nil, err
+			}
+			sel.Targets = append(sel.Targets, target)
+			if !p.accept(COMMA) {
+				break
+			}
+		}
+	}
+
+	if p.cur.Type == FROM {
+		from, err := p.parseFrom()
+		if err != nil {
+			return nil, err
+		}
+		sel.From = from
+	}
+
+	if p.accept(WHERE) {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		sel.Where = expr
+	}
+
+	if p.cur.Type == GROUP {
+		p.next()
+		if _, err := p.expect(BY, "GROUP BY"); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		sel.GroupBy = exprs
+	}
+
+	if p.cur.Type == ORDER {
+		p.next()
+		if _, err := p.expect(BY, "ORDER BY"); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		sel.OrderBy = exprs
+		if p.accept(DESC) {
+			sel.OrderDesc = true
+		} else {
+			p.accept(ASC)
+		}
+	}
+
+	if p.cur.Type == PIVOT {
+		p.next()
+		if _, err := p.expect(BY, "PIVOT BY"); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		sel.PivotBy = exprs
+	}
+
+	if p.cur.Type == LIMIT {
+		p.next()
+		tok, err := p.expect(INTEGER, "LIMIT")
+		if err != nil {
+			return nil, err
+		}
+		limit, err := strconv.ParseInt(tok.String(p.source), 10, 64)
+		if err != nil {
+			return nil, p.errorf(tok, "invalid LIMIT value %q", tok.String(p.source))
+		}
+		sel.Limit = &limit
+	}
+
+	return sel, nil
+}
+
+func (p *parser) parseTarget() (Target, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return Target{}, err
+	}
+	target := Target{Expr: expr}
+	if p.accept(AS) {
+		tok, err := p.expect(IDENT, "target alias")
+		if err != nil {
+			return Target{}, err
+		}
+		target.As = tok.String(p.source)
+	}
+	return target, nil
+}
+
+// parseFrom parses a FROM clause: an optional entry filter expression
+// followed by optional OPEN ON, CLOSE [ON], and CLEAR transforms, in that
+// order (matching the official grammar).
+func (p *parser) parseFrom() (*From, error) {
+	tok := p.cur
+	p.next() // FROM
+
+	from := &From{position: position{p.pos(tok)}}
+
+	if p.startsExpr() {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		from.Expr = expr
+	}
+
+	if p.cur.Type == OPEN {
+		p.next()
+		if _, err := p.expect(ON, "FROM ... OPEN"); err != nil {
+			return nil, err
+		}
+		date, err := p.parseDate()
+		if err != nil {
+			return nil, err
+		}
+		from.OpenOn = date
+	}
+
+	if p.cur.Type == CLOSE {
+		p.next()
+		from.Close = true
+		if p.accept(ON) {
+			date, err := p.parseDate()
+			if err != nil {
+				return nil, err
+			}
+			from.CloseOn = date
+		}
+	}
+
+	if p.cur.Type == CLEAR {
+		p.next()
+		from.Clear = true
+	}
+
+	if from.Expr == nil && from.OpenOn == nil && !from.Close && !from.Clear {
+		return nil, p.errorf(p.cur, "expected expression, OPEN, CLOSE or CLEAR after FROM, found %s", p.describe(p.cur))
+	}
+
+	return from, nil
+}
+
+func (p *parser) parseBalances() (*Balances, error) {
+	tok := p.cur
+	p.next() // BALANCES
+
+	stmt := &Balances{position: position{p.pos(tok)}}
+	summary, err := p.parseAtSummary()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Summary = summary
+
+	if p.cur.Type == FROM {
+		from, err := p.parseFrom()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+	}
+	return stmt, nil
+}
+
+func (p *parser) parseJournal() (*Journal, error) {
+	tok := p.cur
+	p.next() // JOURNAL
+
+	stmt := &Journal{position: position{p.pos(tok)}}
+	if p.cur.Type == STRING {
+		stmt.Account = stripQuotes(p.cur.String(p.source))
+		p.next()
+	}
+
+	summary, err := p.parseAtSummary()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Summary = summary
+
+	if p.cur.Type == FROM {
+		from, err := p.parseFrom()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+	}
+	return stmt, nil
+}
+
+func (p *parser) parsePrint() (*Print, error) {
+	tok := p.cur
+	p.next() // PRINT
+
+	stmt := &Print{position: position{p.pos(tok)}}
+	if p.cur.Type == FROM {
+		from, err := p.parseFrom()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+	}
+	return stmt, nil
+}
+
+func (p *parser) parseAtSummary() (string, error) {
+	if !p.accept(AT) {
+		return "", nil
+	}
+	tok, err := p.expect(IDENT, "AT")
+	if err != nil {
+		return "", err
+	}
+	return tok.String(p.source), nil
+}
+
+func (p *parser) parseExprList() ([]Expr, error) {
+	var exprs []Expr
+	for {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+		if !p.accept(COMMA) {
+			break
+		}
+	}
+	return exprs, nil
+}
+
+// Expression precedence, low to high: OR, AND, NOT, comparison, additive,
+// multiplicative, unary, primary.
+
+func (p *parser) parseExpr() (Expr, error) {
+	return p.parseOr()
+}
+
+func (p *parser) parseOr() (Expr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == OR {
+		tok := p.cur
+		p.next()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &Binary{position: position{p.pos(tok)}, Op: OR, L: left, R: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (Expr, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == AND {
+		tok := p.cur
+		p.next()
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = &Binary{position: position{p.pos(tok)}, Op: AND, L: left, R: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseNot() (Expr, error) {
+	if p.cur.Type == NOT {
+		tok := p.cur
+		p.next()
+		x, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return &Unary{position: position{p.pos(tok)}, Op: NOT, X: x}, nil
+	}
+	return p.parseComparison()
+}
+
+// parseComparison parses a non-associative comparison: at most one comparison
+// operator between two additive expressions.
+func (p *parser) parseComparison() (Expr, error) {
+	left, err := p.parseAdditive()
+	if err != nil {
+		return nil, err
+	}
+	switch p.cur.Type {
+	case EQ, NE, LT, LTE, GT, GTE, TILDE, IN:
+		tok := p.cur
+		p.next()
+		right, err := p.parseAdditive()
+		if err != nil {
+			return nil, err
+		}
+		return &Binary{position: position{p.pos(tok)}, Op: tok.Type, L: left, R: right}, nil
+	}
+	return left, nil
+}
+
+func (p *parser) parseAdditive() (Expr, error) {
+	left, err := p.parseMultiplicative()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == PLUS || p.cur.Type == MINUS {
+		tok := p.cur
+		p.next()
+		right, err := p.parseMultiplicative()
+		if err != nil {
+			return nil, err
+		}
+		left = &Binary{position: position{p.pos(tok)}, Op: tok.Type, L: left, R: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseMultiplicative() (Expr, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == ASTERISK || p.cur.Type == SLASH {
+		tok := p.cur
+		p.next()
+		right, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = &Binary{position: position{p.pos(tok)}, Op: tok.Type, L: left, R: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseUnary() (Expr, error) {
+	if p.cur.Type == MINUS || p.cur.Type == PLUS {
+		tok := p.cur
+		p.next()
+		x, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &Unary{position: position{p.pos(tok)}, Op: tok.Type, X: x}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (Expr, error) {
+	tok := p.cur
+	switch tok.Type {
+	case LPAREN:
+		p.next()
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(RPAREN, "parenthesized expression"); err != nil {
+			return nil, err
+		}
+		return expr, nil
+
+	case STRING:
+		p.next()
+		return &Str{position: position{p.pos(tok)}, Value: stripQuotes(tok.String(p.source))}, nil
+
+	case INTEGER:
+		p.next()
+		value, err := strconv.ParseInt(tok.String(p.source), 10, 64)
+		if err != nil {
+			return nil, p.errorf(tok, "invalid integer %q", tok.String(p.source))
+		}
+		return &Int{position: position{p.pos(tok)}, Value: value}, nil
+
+	case DECIMAL:
+		p.next()
+		value, err := decimal.NewFromString(tok.String(p.source))
+		if err != nil {
+			return nil, p.errorf(tok, "invalid decimal %q", tok.String(p.source))
+		}
+		return &Dec{position: position{p.pos(tok)}, Value: value}, nil
+
+	case DATE:
+		p.next()
+		date := &ast.Date{}
+		if err := date.Capture([]string{tok.String(p.source)}); err != nil {
+			return nil, p.errorf(tok, "invalid date %q", tok.String(p.source))
+		}
+		return &DateLit{position: position{p.pos(tok)}, Value: date}, nil
+
+	case TRUE, FALSE:
+		p.next()
+		return &Bool{position: position{p.pos(tok)}, Value: tok.Type == TRUE}, nil
+
+	case NULL:
+		p.next()
+		return &Null{position: position{p.pos(tok)}}, nil
+
+	case IDENT:
+		p.next()
+		name := tok.String(p.source)
+		if p.cur.Type != LPAREN {
+			return &Ident{position: position{p.pos(tok)}, Name: name}, nil
+		}
+		p.next() // (
+		call := &Call{position: position{p.pos(tok)}, Func: name}
+		if p.cur.Type != RPAREN {
+			args, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			call.Args = args
+		}
+		if _, err := p.expect(RPAREN, "function call"); err != nil {
+			return nil, err
+		}
+		return call, nil
+	}
+
+	return nil, p.errorf(tok, "expected expression, found %s", p.describe(tok))
+}
+
+// parseDate parses a DATE token into an ast.Date, validating its value.
+func (p *parser) parseDate() (*ast.Date, error) {
+	tok, err := p.expect(DATE, "date")
+	if err != nil {
+		return nil, err
+	}
+	date := &ast.Date{}
+	if err := date.Capture([]string{tok.String(p.source)}); err != nil {
+		return nil, p.errorf(tok, "invalid date %q", tok.String(p.source))
+	}
+	return date, nil
+}
+
+// startsExpr reports whether the current token can begin an expression. Used
+// to decide whether a FROM clause has a filter expression before its
+// OPEN/CLOSE/CLEAR transforms.
+func (p *parser) startsExpr() bool {
+	switch p.cur.Type {
+	case LPAREN, STRING, INTEGER, DECIMAL, DATE, TRUE, FALSE, NULL, IDENT, NOT, MINUS, PLUS:
+		return true
+	}
+	return false
+}
+
+func stripQuotes(s string) string {
+	if len(s) >= 2 {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/query/bql/parser_fuzz_test.go
+++ b/query/bql/parser_fuzz_test.go
@@ -1,0 +1,61 @@
+package bql
+
+import (
+	"testing"
+)
+
+func FuzzParseQuery(f *testing.F) {
+	seeds := []string{
+		// Core SELECT forms
+		"SELECT *",
+		"SELECT date, account, position",
+		"SELECT DISTINCT account",
+		"SELECT account AS a, sum(position) AS total GROUP BY a",
+		"SELECT account, sum(position) FROM year = 2014 WHERE number > 0 GROUP BY account ORDER BY account, date DESC LIMIT 10",
+
+		// Expressions
+		"SELECT * WHERE a = 1 OR b = 2 AND NOT c = 3",
+		"SELECT (1 + 2) * 3 - -4 / 5",
+		"SELECT * WHERE account ~ 'Expenses' AND 'trip' IN tags",
+		"SELECT year(date), month(date), parent(account)",
+		"SELECT * WHERE date >= 2014-01-01 AND date < 2015-01-01",
+		`SELECT "double", 'single', 42, 3.14, TRUE, FALSE, NULL`,
+
+		// FROM transforms
+		"SELECT * FROM OPEN ON 2014-01-01 CLOSE ON 2015-01-01 CLEAR",
+		"SELECT * FROM CLOSE",
+		"SELECT * FROM year = 2014 CLEAR",
+
+		// Shortcut statements
+		"BALANCES",
+		"BALANCES AT cost FROM year = 2014",
+		`JOURNAL "Assets:Checking" AT units`,
+		"PRINT FROM account ~ 'Expenses'",
+
+		// Pivot, semicolons, multi-line
+		"SELECT account, year(date), sum(position) GROUP BY 1, 2 PIVOT BY account, year",
+		"SELECT * ;",
+		"SELECT\n  account\nORDER BY account",
+
+		// Edge cases
+		"",
+		"   \n\t ",
+		"SELECT",
+		"select * where !",
+		"SELECT 'unterminated",
+		"SELECT 9999999999999999999999999",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, query string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("parser panicked on input %q: %v", query, r)
+			}
+		}()
+		// The parser must never panic; errors are fine.
+		_, _ = Parse(query)
+	})
+}

--- a/query/bql/parser_test.go
+++ b/query/bql/parser_test.go
@@ -1,0 +1,308 @@
+package bql
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestParseSelectWildcard(t *testing.T) {
+	stmt, err := Parse("SELECT *")
+	assert.NoError(t, err)
+
+	sel := stmt.(*Select)
+	assert.True(t, sel.Wildcard)
+	assert.Zero(t, len(sel.Targets))
+}
+
+func TestParseSelectTargets(t *testing.T) {
+	stmt, err := Parse("SELECT date, account, position AS pos")
+	assert.NoError(t, err)
+
+	sel := stmt.(*Select)
+	assert.False(t, sel.Wildcard)
+	assert.Equal(t, 3, len(sel.Targets))
+	assert.Equal(t, "date", sel.Targets[0].Expr.(*Ident).Name)
+	assert.Equal(t, "", sel.Targets[0].As)
+	assert.Equal(t, "pos", sel.Targets[2].As)
+}
+
+func TestParseSelectDistinct(t *testing.T) {
+	stmt, err := Parse("SELECT DISTINCT account")
+	assert.NoError(t, err)
+	assert.True(t, stmt.(*Select).Distinct)
+}
+
+func TestParseSelectCaseInsensitiveKeywords(t *testing.T) {
+	stmt, err := Parse("select distinct account from year = 2014 where number > 0 group by account order by account desc limit 10")
+	assert.NoError(t, err)
+
+	sel := stmt.(*Select)
+	assert.True(t, sel.Distinct)
+	assert.NotZero(t, sel.From)
+	assert.NotZero(t, sel.Where)
+	assert.Equal(t, 1, len(sel.GroupBy))
+	assert.Equal(t, 1, len(sel.OrderBy))
+	assert.True(t, sel.OrderDesc)
+	assert.Equal(t, int64(10), *sel.Limit)
+}
+
+func TestParseFunctionCall(t *testing.T) {
+	stmt, err := Parse("SELECT account, sum(position) GROUP BY account")
+	assert.NoError(t, err)
+
+	sel := stmt.(*Select)
+	call := sel.Targets[1].Expr.(*Call)
+	assert.Equal(t, "sum", call.Func)
+	assert.Equal(t, 1, len(call.Args))
+	assert.Equal(t, "position", call.Args[0].(*Ident).Name)
+}
+
+func TestParseNestedFunctionCall(t *testing.T) {
+	stmt, err := Parse("SELECT sum(cost(position))")
+	assert.NoError(t, err)
+
+	call := stmt.(*Select).Targets[0].Expr.(*Call)
+	assert.Equal(t, "sum", call.Func)
+	inner := call.Args[0].(*Call)
+	assert.Equal(t, "cost", inner.Func)
+}
+
+func TestParseFunctionCallNoArgs(t *testing.T) {
+	stmt, err := Parse("SELECT today()")
+	assert.NoError(t, err)
+
+	call := stmt.(*Select).Targets[0].Expr.(*Call)
+	assert.Equal(t, "today", call.Func)
+	assert.Zero(t, len(call.Args))
+}
+
+func TestParseWherePrecedence(t *testing.T) {
+	// NOT binds tighter than AND, AND tighter than OR.
+	stmt, err := Parse("SELECT * WHERE a = 1 OR b = 2 AND NOT c = 3")
+	assert.NoError(t, err)
+
+	where := stmt.(*Select).Where.(*Binary)
+	assert.Equal(t, OR, where.Op)
+	right := where.R.(*Binary)
+	assert.Equal(t, AND, right.Op)
+	not := right.R.(*Unary)
+	assert.Equal(t, NOT, not.Op)
+}
+
+func TestParseArithmeticPrecedence(t *testing.T) {
+	stmt, err := Parse("SELECT 1 + 2 * 3")
+	assert.NoError(t, err)
+
+	expr := stmt.(*Select).Targets[0].Expr.(*Binary)
+	assert.Equal(t, PLUS, expr.Op)
+	assert.Equal(t, int64(1), expr.L.(*Int).Value)
+	mul := expr.R.(*Binary)
+	assert.Equal(t, ASTERISK, mul.Op)
+}
+
+func TestParseComparisonOperators(t *testing.T) {
+	for _, tt := range []struct {
+		query string
+		op    TokenType
+	}{
+		{"SELECT * WHERE a = 1", EQ},
+		{"SELECT * WHERE a != 1", NE},
+		{"SELECT * WHERE a < 1", LT},
+		{"SELECT * WHERE a <= 1", LTE},
+		{"SELECT * WHERE a > 1", GT},
+		{"SELECT * WHERE a >= 1", GTE},
+		{"SELECT * WHERE account ~ 'Expenses'", TILDE},
+		{"SELECT * WHERE 'trip' IN tags", IN},
+	} {
+		stmt, err := Parse(tt.query)
+		assert.NoError(t, err, tt.query)
+		assert.Equal(t, tt.op, stmt.(*Select).Where.(*Binary).Op, tt.query)
+	}
+}
+
+func TestParseLiterals(t *testing.T) {
+	stmt, err := Parse(`SELECT "double", 'single', 42, 3.14, 2014-01-01, TRUE, FALSE, NULL`)
+	assert.NoError(t, err)
+
+	targets := stmt.(*Select).Targets
+	assert.Equal(t, "double", targets[0].Expr.(*Str).Value)
+	assert.Equal(t, "single", targets[1].Expr.(*Str).Value)
+	assert.Equal(t, int64(42), targets[2].Expr.(*Int).Value)
+	assert.Equal(t, "3.14", targets[3].Expr.(*Dec).Value.String())
+	assert.Equal(t, "2014-01-01", targets[4].Expr.(*DateLit).Value.String())
+	assert.True(t, targets[5].Expr.(*Bool).Value)
+	assert.False(t, targets[6].Expr.(*Bool).Value)
+	_, isNull := targets[7].Expr.(*Null)
+	assert.True(t, isNull)
+}
+
+func TestParseUnaryMinus(t *testing.T) {
+	stmt, err := Parse("SELECT -number")
+	assert.NoError(t, err)
+
+	unary := stmt.(*Select).Targets[0].Expr.(*Unary)
+	assert.Equal(t, MINUS, unary.Op)
+	assert.Equal(t, "number", unary.X.(*Ident).Name)
+}
+
+func TestParseParenthesizedExpression(t *testing.T) {
+	stmt, err := Parse("SELECT (1 + 2) * 3")
+	assert.NoError(t, err)
+
+	expr := stmt.(*Select).Targets[0].Expr.(*Binary)
+	assert.Equal(t, ASTERISK, expr.Op)
+	assert.Equal(t, PLUS, expr.L.(*Binary).Op)
+}
+
+func TestParseFromExpression(t *testing.T) {
+	stmt, err := Parse("SELECT * FROM year = 2014 AND account ~ 'Assets'")
+	assert.NoError(t, err)
+
+	from := stmt.(*Select).From
+	assert.NotZero(t, from.Expr)
+	assert.Equal(t, AND, from.Expr.(*Binary).Op)
+}
+
+func TestParseFromTransforms(t *testing.T) {
+	stmt, err := Parse("SELECT * FROM year = 2014 OPEN ON 2014-01-01 CLOSE ON 2015-01-01 CLEAR")
+	assert.NoError(t, err)
+
+	from := stmt.(*Select).From
+	assert.NotZero(t, from.Expr)
+	assert.Equal(t, "2014-01-01", from.OpenOn.String())
+	assert.True(t, from.Close)
+	assert.Equal(t, "2015-01-01", from.CloseOn.String())
+	assert.True(t, from.Clear)
+}
+
+func TestParseFromBareClose(t *testing.T) {
+	stmt, err := Parse("SELECT * FROM CLOSE")
+	assert.NoError(t, err)
+
+	from := stmt.(*Select).From
+	assert.Zero(t, from.Expr)
+	assert.True(t, from.Close)
+	assert.Zero(t, from.CloseOn)
+}
+
+func TestParseFromTransformsOnly(t *testing.T) {
+	stmt, err := Parse("SELECT * FROM OPEN ON 2014-01-01")
+	assert.NoError(t, err)
+
+	from := stmt.(*Select).From
+	assert.Zero(t, from.Expr)
+	assert.Equal(t, "2014-01-01", from.OpenOn.String())
+}
+
+func TestParseGroupByIndexAndName(t *testing.T) {
+	stmt, err := Parse("SELECT account, year(date) GROUP BY 1, year(date)")
+	assert.NoError(t, err)
+
+	groupBy := stmt.(*Select).GroupBy
+	assert.Equal(t, 2, len(groupBy))
+	assert.Equal(t, int64(1), groupBy[0].(*Int).Value)
+	assert.Equal(t, "year", groupBy[1].(*Call).Func)
+}
+
+func TestParseOrderByList(t *testing.T) {
+	// The official grammar accepts a single trailing ASC/DESC that applies
+	// to the whole ORDER BY list, not one direction per term.
+	stmt, err := Parse("SELECT * ORDER BY date, account DESC")
+	assert.NoError(t, err)
+
+	sel := stmt.(*Select)
+	assert.Equal(t, 2, len(sel.OrderBy))
+	assert.True(t, sel.OrderDesc)
+
+	_, err = Parse("SELECT * ORDER BY date DESC, account ASC")
+	assert.Error(t, err)
+}
+
+func TestParsePivotBy(t *testing.T) {
+	stmt, err := Parse("SELECT account, year(date), sum(position) GROUP BY 1, 2 PIVOT BY account, year")
+	assert.NoError(t, err)
+
+	pivotBy := stmt.(*Select).PivotBy
+	assert.Equal(t, 2, len(pivotBy))
+}
+
+func TestParseTrailingSemicolon(t *testing.T) {
+	_, err := Parse("SELECT * ;")
+	assert.NoError(t, err)
+}
+
+func TestParseBalances(t *testing.T) {
+	stmt, err := Parse("BALANCES AT cost FROM year = 2014")
+	assert.NoError(t, err)
+
+	balances := stmt.(*Balances)
+	assert.Equal(t, "cost", balances.Summary)
+	assert.NotZero(t, balances.From)
+}
+
+func TestParseBalancesBare(t *testing.T) {
+	stmt, err := Parse("BALANCES")
+	assert.NoError(t, err)
+
+	balances := stmt.(*Balances)
+	assert.Equal(t, "", balances.Summary)
+	assert.Zero(t, balances.From)
+}
+
+func TestParseJournal(t *testing.T) {
+	stmt, err := Parse(`JOURNAL "Assets:Checking" AT units FROM year = 2014`)
+	assert.NoError(t, err)
+
+	journal := stmt.(*Journal)
+	assert.Equal(t, "Assets:Checking", journal.Account)
+	assert.Equal(t, "units", journal.Summary)
+	assert.NotZero(t, journal.From)
+}
+
+func TestParsePrint(t *testing.T) {
+	stmt, err := Parse("PRINT FROM account ~ 'Expenses'")
+	assert.NoError(t, err)
+	assert.NotZero(t, stmt.(*Print).From)
+}
+
+func TestParseErrors(t *testing.T) {
+	for _, query := range []string{
+		"",
+		"FOO",
+		"SELECT",
+		"SELECT date,",
+		"SELECT * WHERE",
+		"SELECT * GROUP account",
+		"SELECT * ORDER BY",
+		"SELECT * LIMIT abc",
+		"SELECT * LIMIT",
+		"SELECT sum(",
+		"SELECT (1 + 2",
+		"SELECT * FROM",
+		"SELECT * FROM OPEN 2014-01-01",
+		"SELECT * FROM OPEN ON",
+		"SELECT * extra",
+		"SELECT 'unterminated",
+		"SELECT a = b = c",
+		"SELECT 2014-13-45",
+	} {
+		_, err := Parse(query)
+		assert.Error(t, err, query)
+	}
+}
+
+func TestParseErrorHasPosition(t *testing.T) {
+	_, err := Parse("SELECT date,\n  bogus(")
+	assert.Error(t, err)
+
+	parseErr := err.(*ParseError)
+	assert.Equal(t, 2, parseErr.Pos.Line)
+	assert.NotZero(t, parseErr.GetPosition())
+}
+
+func TestParseMultilineQuery(t *testing.T) {
+	stmt, err := Parse("SELECT\n  account,\n  sum(position)\nGROUP BY account\nORDER BY account")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(stmt.(*Select).Targets))
+}

--- a/query/bql/token.go
+++ b/query/bql/token.go
@@ -1,0 +1,193 @@
+package bql
+
+// TokenType represents the type of token scanned from a BQL query string.
+type TokenType uint8
+
+const (
+	// Special tokens
+	EOF TokenType = iota
+	ILLEGAL
+
+	// Keywords - statements
+	SELECT
+	BALANCES
+	JOURNAL
+	PRINT
+
+	// Keywords - clauses
+	DISTINCT
+	FROM
+	WHERE
+	GROUP
+	ORDER
+	PIVOT
+	BY
+	ASC
+	DESC
+	LIMIT
+	AS
+	AT
+
+	// Keywords - FROM transforms
+	OPEN
+	CLOSE
+	CLEAR
+	ON
+
+	// Keywords - operators and literals
+	AND
+	OR
+	NOT
+	IN
+	TRUE
+	FALSE
+	NULL
+
+	// Literals
+	IDENT   // column or function name
+	STRING  // "quoted" or 'quoted'
+	INTEGER // 123
+	DECIMAL // 123.45
+	DATE    // YYYY-MM-DD
+
+	// Symbols
+	LPAREN    // (
+	RPAREN    // )
+	COMMA     // ,
+	SEMICOLON // ;
+	ASTERISK  // *
+	SLASH     // /
+	PLUS      // +
+	MINUS     // -
+	TILDE     // ~
+	EQ        // =
+	NE        // !=
+	LT        // <
+	LTE       // <=
+	GT        // >
+	GTE       // >=
+)
+
+var tokenNames = map[TokenType]string{
+	EOF:     "EOF",
+	ILLEGAL: "ILLEGAL",
+
+	SELECT:   "SELECT",
+	BALANCES: "BALANCES",
+	JOURNAL:  "JOURNAL",
+	PRINT:    "PRINT",
+
+	DISTINCT: "DISTINCT",
+	FROM:     "FROM",
+	WHERE:    "WHERE",
+	GROUP:    "GROUP",
+	ORDER:    "ORDER",
+	PIVOT:    "PIVOT",
+	BY:       "BY",
+	ASC:      "ASC",
+	DESC:     "DESC",
+	LIMIT:    "LIMIT",
+	AS:       "AS",
+	AT:       "AT",
+
+	OPEN:  "OPEN",
+	CLOSE: "CLOSE",
+	CLEAR: "CLEAR",
+	ON:    "ON",
+
+	AND:   "AND",
+	OR:    "OR",
+	NOT:   "NOT",
+	IN:    "IN",
+	TRUE:  "TRUE",
+	FALSE: "FALSE",
+	NULL:  "NULL",
+
+	IDENT:   "IDENT",
+	STRING:  "STRING",
+	INTEGER: "INTEGER",
+	DECIMAL: "DECIMAL",
+	DATE:    "DATE",
+
+	LPAREN:    "(",
+	RPAREN:    ")",
+	COMMA:     ",",
+	SEMICOLON: ";",
+	ASTERISK:  "*",
+	SLASH:     "/",
+	PLUS:      "+",
+	MINUS:     "-",
+	TILDE:     "~",
+	EQ:        "=",
+	NE:        "!=",
+	LT:        "<",
+	LTE:       "<=",
+	GT:        ">",
+	GTE:       ">=",
+}
+
+func (t TokenType) String() string {
+	if name, ok := tokenNames[t]; ok {
+		return name
+	}
+	return "UNKNOWN"
+}
+
+// keywords maps upper-cased identifier text to keyword token types.
+// BQL keywords are case-insensitive.
+var keywords = map[string]TokenType{
+	"SELECT":   SELECT,
+	"BALANCES": BALANCES,
+	"JOURNAL":  JOURNAL,
+	"PRINT":    PRINT,
+	"DISTINCT": DISTINCT,
+	"FROM":     FROM,
+	"WHERE":    WHERE,
+	"GROUP":    GROUP,
+	"ORDER":    ORDER,
+	"PIVOT":    PIVOT,
+	"BY":       BY,
+	"ASC":      ASC,
+	"DESC":     DESC,
+	"LIMIT":    LIMIT,
+	"AS":       AS,
+	"AT":       AT,
+	"OPEN":     OPEN,
+	"CLOSE":    CLOSE,
+	"CLEAR":    CLEAR,
+	"ON":       ON,
+	"AND":      AND,
+	"OR":       OR,
+	"NOT":      NOT,
+	"IN":       IN,
+	"TRUE":     TRUE,
+	"FALSE":    FALSE,
+	"NULL":     NULL,
+}
+
+// Token represents a lexical token with zero-copy semantics. Like the core
+// beancount parser, tokens store byte offsets into the source buffer instead
+// of materialized strings.
+type Token struct {
+	Type   TokenType
+	Start  int // Byte offset into source buffer
+	End    int // End offset (exclusive)
+	Line   int // Line number (1-indexed)
+	Column int // Column number (1-indexed)
+}
+
+// String materializes the token text from the source buffer.
+func (t Token) String(source []byte) string {
+	if t.Start >= len(source) || t.End > len(source) || t.Start > t.End {
+		return ""
+	}
+	return string(source[t.Start:t.End])
+}
+
+// Bytes returns a zero-copy view of the token text.
+func (t Token) Bytes(source []byte) []byte {
+	if t.Start >= len(source) || t.End > len(source) || t.Start > t.End {
+		return nil
+	}
+	return source[t.Start:t.End]
+}

--- a/query/compile.go
+++ b/query/compile.go
@@ -1,0 +1,718 @@
+package query
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/query/bql"
+	"github.com/shopspring/decimal"
+)
+
+// CompileError represents a semantic error found while compiling a query.
+type CompileError struct {
+	Pos     ast.Position
+	Message string
+}
+
+func (e *CompileError) Error() string {
+	return e.Message
+}
+
+// GetPosition implements the positioned-error interface used by the CLI
+// error renderer.
+func (e *CompileError) GetPosition() ast.Position {
+	return e.Pos
+}
+
+func compileErrorf(node bql.Node, format string, args ...any) *CompileError {
+	return &CompileError{Pos: node.Pos(), Message: fmt.Sprintf(format, args...)}
+}
+
+// cexpr is a compiled expression: a typed, evaluatable tree node.
+type cexpr interface {
+	typ() DType
+	eval(row *Row) any
+}
+
+// Compiled is a fully resolved SELECT ready for execution. GroupBy, OrderBy,
+// and PivotBy reference targets by index; hidden targets were appended
+// during resolution and are not rendered.
+type Compiled struct {
+	Targets   []CompiledTarget
+	Where     cexpr
+	From      *CompiledFrom
+	GroupBy   []int
+	OrderBy   []int
+	OrderDesc bool
+	PivotBy   []int
+	Limit     *int64
+	Distinct  bool
+	HasAgg    bool
+	Aggs      []*cAgg
+	// UsesBalance is set when the running balance column is referenced,
+	// so the executor can skip per-row inventory snapshots otherwise.
+	UsesBalance bool
+}
+
+// CompiledTarget is one output column (or hidden sort/group key).
+type CompiledTarget struct {
+	Name   string
+	Type   DType
+	Hidden bool
+	IsAgg  bool // the expression contains an aggregate function
+	expr   cexpr
+	key    string // canonical expression key for structural matching
+}
+
+// CompiledFrom is the compiled FROM clause: an entry-level filter plus
+// summarization transforms applied by the executor.
+type CompiledFrom struct {
+	Expr    cexpr
+	OpenOn  *ast.Date
+	Close   bool
+	CloseOn *ast.Date
+	Clear   bool
+}
+
+// Compile resolves and type-checks a parsed BQL statement against the query
+// environments. BALANCES and JOURNAL desugar to their SELECT expansions;
+// PRINT compiles separately via CompilePrint.
+func Compile(ctx *Context, stmt bql.Statement) (*Compiled, error) {
+	sel, ok := Desugar(stmt).(*bql.Select)
+	if !ok {
+		return nil, fmt.Errorf("statement %T is not supported yet", stmt)
+	}
+	c := &compiler{ctx: ctx}
+	return c.compileSelect(sel)
+}
+
+type compiler struct {
+	ctx         *Context
+	env         *environment
+	aggs        []*cAgg
+	usesBalance bool
+}
+
+func (c *compiler) compileSelect(sel *bql.Select) (*Compiled, error) {
+	compiled := &Compiled{Distinct: sel.Distinct, Limit: sel.Limit}
+
+	// FROM compiles against the entry environment, everything else against
+	// the posting environment.
+	if sel.From != nil {
+		from := &CompiledFrom{
+			OpenOn:  sel.From.OpenOn,
+			Close:   sel.From.Close,
+			CloseOn: sel.From.CloseOn,
+			Clear:   sel.From.Clear,
+		}
+		if sel.From.Expr != nil {
+			c.env = filterEnv
+			expr, err := c.compileExpr(sel.From.Expr, false)
+			if err != nil {
+				return nil, err
+			}
+			from.Expr = expr
+		}
+		compiled.From = from
+	}
+
+	c.env = targetsEnv
+
+	// Targets: expand the wildcard or compile the explicit list.
+	targets := sel.Targets
+	if sel.Wildcard {
+		targets = make([]bql.Target, len(wildcardColumns))
+		for i, name := range wildcardColumns {
+			targets[i] = bql.Target{Expr: &bql.Ident{Name: name}}
+		}
+	}
+	for _, target := range targets {
+		before := len(c.aggs)
+		expr, err := c.compileExpr(target.Expr, true)
+		if err != nil {
+			return nil, err
+		}
+		name := target.As
+		if name == "" {
+			name = deriveName(target.Expr)
+		}
+		compiled.Targets = append(compiled.Targets, CompiledTarget{
+			Name:  name,
+			Type:  expr.typ(),
+			IsAgg: len(c.aggs) > before,
+			expr:  expr,
+			key:   exprKey(target.Expr),
+		})
+	}
+
+	if sel.Where != nil {
+		before := len(c.aggs)
+		expr, err := c.compileExpr(sel.Where, false)
+		if err != nil {
+			return nil, err
+		}
+		if len(c.aggs) > before {
+			return nil, compileErrorf(sel.Where, "Aggregates are disallowed in WHERE clause.")
+		}
+		compiled.Where = expr
+	}
+
+	if err := c.resolveGroupBy(sel, compiled); err != nil {
+		return nil, err
+	}
+	if err := c.resolveOrderBy(sel, compiled); err != nil {
+		return nil, err
+	}
+	if err := c.resolvePivotBy(sel, compiled); err != nil {
+		return nil, err
+	}
+
+	compiled.HasAgg = false
+	for _, target := range compiled.Targets {
+		if target.IsAgg {
+			compiled.HasAgg = true
+			break
+		}
+	}
+	compiled.Aggs = c.aggs
+	compiled.UsesBalance = c.usesBalance
+
+	if err := checkGroupCoverage(sel, compiled); err != nil {
+		return nil, err
+	}
+	return compiled, nil
+}
+
+// resolveGroupBy maps GROUP BY items to target indices, appending hidden
+// targets for expressions that are not in the select list. Without an
+// explicit GROUP BY, an aggregate query implicitly groups by all
+// non-aggregate targets (official behavior).
+func (c *compiler) resolveGroupBy(sel *bql.Select, compiled *Compiled) error {
+	if len(sel.GroupBy) == 0 {
+		hasAgg := false
+		for _, target := range compiled.Targets {
+			if target.IsAgg {
+				hasAgg = true
+				break
+			}
+		}
+		if hasAgg {
+			for i, target := range compiled.Targets {
+				if !target.IsAgg {
+					compiled.GroupBy = append(compiled.GroupBy, i)
+				}
+			}
+		}
+		return nil
+	}
+
+	for _, item := range sel.GroupBy {
+		idx, err := c.resolveTargetRef(item, compiled, false)
+		if err != nil {
+			return err
+		}
+		if compiled.Targets[idx].IsAgg {
+			return compileErrorf(item, "GROUP-BY expressions may not be aggregates.")
+		}
+		compiled.GroupBy = append(compiled.GroupBy, idx)
+	}
+	return nil
+}
+
+// resolveOrderBy maps ORDER BY expressions to target indices, appending
+// hidden targets as needed. A single trailing direction applies to the
+// whole list.
+func (c *compiler) resolveOrderBy(sel *bql.Select, compiled *Compiled) error {
+	compiled.OrderDesc = sel.OrderDesc
+	for _, item := range sel.OrderBy {
+		idx, err := c.resolveTargetRef(item, compiled, true)
+		if err != nil {
+			return err
+		}
+		compiled.OrderBy = append(compiled.OrderBy, idx)
+	}
+	return nil
+}
+
+func (c *compiler) resolvePivotBy(sel *bql.Select, compiled *Compiled) error {
+	for _, item := range sel.PivotBy {
+		idx, err := c.resolveTargetRef(item, compiled, false)
+		if err != nil {
+			return err
+		}
+		compiled.PivotBy = append(compiled.PivotBy, idx)
+	}
+	return nil
+}
+
+// resolveTargetRef resolves a clause item to a target index. Integer
+// literals are 1-based indices into the visible targets; identifiers match
+// aliases; other expressions match targets structurally or are appended as
+// hidden targets.
+func (c *compiler) resolveTargetRef(item bql.Expr, compiled *Compiled, allowAgg bool) (int, error) {
+	if lit, ok := item.(*bql.Int); ok {
+		idx := int(lit.Value)
+		visible := 0
+		for _, target := range compiled.Targets {
+			if !target.Hidden {
+				visible++
+			}
+		}
+		if idx < 1 || idx > visible {
+			return 0, compileErrorf(item, "Invalid GROUP-BY column index %d", idx)
+		}
+		return idx - 1, nil
+	}
+
+	if ident, ok := item.(*bql.Ident); ok {
+		for i, target := range compiled.Targets {
+			if !target.Hidden && target.Name == ident.Name {
+				return i, nil
+			}
+		}
+	}
+
+	key := exprKey(item)
+	for i, target := range compiled.Targets {
+		if target.key == key {
+			return i, nil
+		}
+	}
+
+	before := len(c.aggs)
+	expr, err := c.compileExpr(item, allowAgg)
+	if err != nil {
+		return 0, err
+	}
+	compiled.Targets = append(compiled.Targets, CompiledTarget{
+		Name:   deriveName(item),
+		Type:   expr.typ(),
+		Hidden: true,
+		IsAgg:  len(c.aggs) > before,
+		expr:   expr,
+		key:    key,
+	})
+	return len(compiled.Targets) - 1, nil
+}
+
+// checkGroupCoverage enforces that grouped queries cover every visible
+// non-aggregate target with a GROUP-BY key, using the official error message.
+func checkGroupCoverage(sel *bql.Select, compiled *Compiled) error {
+	if !compiled.HasAgg && len(sel.GroupBy) == 0 {
+		return nil
+	}
+	grouped := make(map[int]bool, len(compiled.GroupBy))
+	for _, idx := range compiled.GroupBy {
+		grouped[idx] = true
+	}
+	var missing []string
+	for i, target := range compiled.Targets {
+		if !target.Hidden && !target.IsAgg && !grouped[i] {
+			missing = append(missing, fmt.Sprintf("%q", target.Name))
+		}
+	}
+	if len(missing) > 0 {
+		return compileErrorf(sel,
+			"All non-aggregates must be covered by GROUP-BY clause in aggregate query; the following targets are missing: %s.",
+			strings.Join(missing, ","))
+	}
+	return nil
+}
+
+// compileExpr compiles a BQL expression against the current environment.
+func (c *compiler) compileExpr(e bql.Expr, allowAgg bool) (cexpr, error) {
+	switch node := e.(type) {
+	case *bql.Str:
+		return &cLiteral{v: node.Value, t: TString}, nil
+	case *bql.Int:
+		return &cLiteral{v: node.Value, t: TInt}, nil
+	case *bql.Dec:
+		return &cLiteral{v: node.Value, t: TDecimal}, nil
+	case *bql.DateLit:
+		return &cLiteral{v: node.Value, t: TDate}, nil
+	case *bql.Bool:
+		return &cLiteral{v: node.Value, t: TBool}, nil
+	case *bql.Null:
+		return &cLiteral{v: nil, t: TAny}, nil
+
+	case *bql.Ident:
+		def, ok := c.env.columns[node.Name]
+		if !ok {
+			return nil, compileErrorf(node, "Invalid column name '%s' in %s.", node.Name, c.env.context)
+		}
+		if node.Name == "balance" {
+			c.usesBalance = true
+		}
+		return &cColumn{def: def}, nil
+
+	case *bql.Call:
+		return c.compileCall(node, allowAgg)
+
+	case *bql.Unary:
+		return c.compileUnary(node, allowAgg)
+
+	case *bql.Binary:
+		return c.compileBinary(node, allowAgg)
+	}
+	return nil, compileErrorf(e, "unsupported expression")
+}
+
+func (c *compiler) compileCall(node *bql.Call, allowAgg bool) (cexpr, error) {
+	name := strings.ToLower(node.Func)
+
+	if aggregate, ok := aggregates[name]; ok {
+		if !allowAgg {
+			return nil, compileErrorf(node, "Aggregates are disallowed in this context.")
+		}
+		if len(node.Args) != 1 {
+			return nil, compileErrorf(node, "Aggregate function '%s' takes exactly one argument.", name)
+		}
+		arg, err := c.compileExpr(node.Args[0], false)
+		if err != nil {
+			return nil, err
+		}
+		result, ok := aggregate.resultType(arg.typ())
+		if !ok {
+			return nil, compileErrorf(node, "Invalid function '%s(%s)' in %s.", name, arg.typ(), c.env.context)
+		}
+		agg := &cAgg{def: aggregate, arg: arg, result: result, slot: len(c.aggs)}
+		c.aggs = append(c.aggs, agg)
+		return agg, nil
+	}
+
+	def, ok := functions[name]
+	if !ok {
+		return nil, compileErrorf(node, "Invalid function '%s(%s)' in %s.", name, argTypeList(nil, node.Args), c.env.context)
+	}
+	args := make([]cexpr, len(node.Args))
+	argTypes := make([]DType, len(node.Args))
+	for i, argNode := range node.Args {
+		arg, err := c.compileExpr(argNode, allowAgg)
+		if err != nil {
+			return nil, err
+		}
+		args[i] = arg
+		argTypes[i] = arg.typ()
+	}
+	overload := def.matchOverload(argTypes)
+	if overload == nil {
+		return nil, compileErrorf(node, "Invalid function '%s(%s)' in %s.", name, argTypeList(argTypes, nil), c.env.context)
+	}
+	return &cCall{overload: overload, args: args}, nil
+}
+
+// argTypeList renders argument types for error messages, falling back to
+// argument text when types are unknown.
+func argTypeList(types []DType, nodes []bql.Expr) string {
+	if types != nil {
+		names := make([]string, len(types))
+		for i, t := range types {
+			names[i] = t.String()
+		}
+		return strings.Join(names, ",")
+	}
+	names := make([]string, len(nodes))
+	for i, node := range nodes {
+		names[i] = deriveName(node)
+	}
+	return strings.Join(names, ",")
+}
+
+func (c *compiler) compileUnary(node *bql.Unary, allowAgg bool) (cexpr, error) {
+	x, err := c.compileExpr(node.X, allowAgg)
+	if err != nil {
+		return nil, err
+	}
+	switch node.Op {
+	case bql.NOT:
+		return &cNot{x: x}, nil
+	case bql.MINUS:
+		return &cNeg{x: x}, nil
+	case bql.PLUS:
+		return x, nil
+	}
+	return nil, compileErrorf(node, "unsupported unary operator")
+}
+
+func (c *compiler) compileBinary(node *bql.Binary, allowAgg bool) (cexpr, error) {
+	l, err := c.compileExpr(node.L, allowAgg)
+	if err != nil {
+		return nil, err
+	}
+	r, err := c.compileExpr(node.R, allowAgg)
+	if err != nil {
+		return nil, err
+	}
+
+	t := TBool
+	switch node.Op {
+	case bql.PLUS, bql.MINUS, bql.ASTERISK:
+		if l.typ() == TInt && r.typ() == TInt {
+			t = TInt
+		} else {
+			t = TDecimal
+		}
+	case bql.SLASH:
+		t = TDecimal
+	}
+	return &cBinary{op: node.Op, l: l, r: r, t: t}, nil
+}
+
+// deriveName builds the default column name for an unaliased target,
+// matching the official naming: columns keep their name, function calls
+// join the function and argument names with underscores, and constants get
+// a "c" prefix with punctuation replaced by underscores.
+func deriveName(e bql.Expr) string {
+	switch node := e.(type) {
+	case *bql.Ident:
+		return strings.ToLower(node.Name)
+	case *bql.Call:
+		parts := make([]string, 0, len(node.Args)+1)
+		parts = append(parts, strings.ToLower(node.Func))
+		for _, arg := range node.Args {
+			parts = append(parts, deriveName(arg))
+		}
+		return strings.Join(parts, "_")
+	case *bql.Str:
+		return "c" + sanitizeName(node.Value)
+	case *bql.Int:
+		return fmt.Sprintf("c%d", node.Value)
+	case *bql.Dec:
+		return "c" + sanitizeName(node.Value.String())
+	case *bql.DateLit:
+		return "c" + sanitizeName(node.Value.String())
+	case *bql.Bool:
+		if node.Value {
+			return "ctrue"
+		}
+		return "cfalse"
+	case *bql.Null:
+		return "cnone"
+	case *bql.Unary:
+		prefix := "neg"
+		if node.Op == bql.NOT {
+			prefix = "not"
+		}
+		return prefix + "_" + deriveName(node.X)
+	case *bql.Binary:
+		return binaryOpNames[node.Op] + "_" + deriveName(node.L) + "_" + deriveName(node.R)
+	}
+	return "expr"
+}
+
+var binaryOpNames = map[bql.TokenType]string{
+	bql.PLUS:     "add",
+	bql.MINUS:    "sub",
+	bql.ASTERISK: "mul",
+	bql.SLASH:    "div",
+	bql.EQ:       "equal",
+	bql.NE:       "not_equal",
+	bql.LT:       "less",
+	bql.LTE:      "less_eq",
+	bql.GT:       "greater",
+	bql.GTE:      "greater_eq",
+	bql.TILDE:    "match",
+	bql.IN:       "in",
+	bql.AND:      "and",
+	bql.OR:       "or",
+}
+
+// nameSanitizer collapses runs of characters outside [a-z0-9_] into a single
+// underscore, without lowercasing first — 'USD' becomes "_", matching the
+// official constant naming (verified against bean-query 2.3.6).
+var nameSanitizer = regexp.MustCompile(`[^a-z0-9_]+`)
+
+func sanitizeName(s string) string {
+	return nameSanitizer.ReplaceAllString(s, "_")
+}
+
+// exprKey builds a canonical key for structural expression matching, used
+// to resolve GROUP-BY and ORDER-BY items against the targets list.
+func exprKey(e bql.Expr) string {
+	return deriveName(e)
+}
+
+// Compiled expression nodes.
+
+type cLiteral struct {
+	v any
+	t DType
+}
+
+func (c *cLiteral) typ() DType    { return c.t }
+func (c *cLiteral) eval(*Row) any { return c.v }
+
+type cColumn struct {
+	def *columnDef
+}
+
+func (c *cColumn) typ() DType        { return c.def.typ }
+func (c *cColumn) eval(row *Row) any { return c.def.eval(row) }
+
+type cCall struct {
+	overload *funcOverload
+	args     []cexpr
+}
+
+func (c *cCall) typ() DType { return c.overload.result }
+
+func (c *cCall) eval(row *Row) any {
+	args := make([]any, len(c.args))
+	for i, arg := range c.args {
+		args[i] = arg.eval(row)
+		// Propagate NULL through typed parameters; polymorphic (TAny)
+		// parameters receive NULL and decide themselves.
+		if args[i] == nil && c.overload.params[i] != TAny {
+			return nil
+		}
+	}
+	return c.overload.call(row, args)
+}
+
+// cAgg is a reference to an aggregate accumulator slot. During accumulation
+// the executor feeds rows to the accumulator; during output evaluation the
+// finalized value is read back from Row.AggValues.
+type cAgg struct {
+	def    *aggDef
+	arg    cexpr
+	result DType
+	slot   int
+}
+
+func (c *cAgg) typ() DType { return c.result }
+
+func (c *cAgg) eval(row *Row) any {
+	if c.slot < len(row.AggValues) {
+		return row.AggValues[c.slot]
+	}
+	return nil
+}
+
+type cNot struct {
+	x cexpr
+}
+
+func (c *cNot) typ() DType        { return TBool }
+func (c *cNot) eval(row *Row) any { return !truthy(c.x.eval(row)) }
+
+type cNeg struct {
+	x cexpr
+}
+
+func (c *cNeg) typ() DType { return c.x.typ() }
+
+func (c *cNeg) eval(row *Row) any {
+	switch v := c.x.eval(row).(type) {
+	case int64:
+		return -v
+	case decimal.Decimal:
+		return v.Neg()
+	}
+	return nil
+}
+
+type cBinary struct {
+	op   bql.TokenType
+	l, r cexpr
+	t    DType
+}
+
+func (c *cBinary) typ() DType { return c.t }
+
+func (c *cBinary) eval(row *Row) any {
+	switch c.op {
+	case bql.AND:
+		return truthy(c.l.eval(row)) && truthy(c.r.eval(row))
+	case bql.OR:
+		return truthy(c.l.eval(row)) || truthy(c.r.eval(row))
+	}
+
+	l := c.l.eval(row)
+	r := c.r.eval(row)
+
+	switch c.op {
+	case bql.EQ:
+		// NULL equals NULL, matching Python's None == None.
+		if l == nil || r == nil {
+			return l == nil && r == nil
+		}
+		return compareValues(l, r) == 0
+	case bql.NE:
+		if l == nil || r == nil {
+			return l != nil || r != nil
+		}
+		return compareValues(l, r) != 0
+	case bql.LT, bql.LTE, bql.GT, bql.GTE:
+		if l == nil || r == nil {
+			return false
+		}
+		cmp := compareValues(l, r)
+		switch c.op {
+		case bql.LT:
+			return cmp < 0
+		case bql.LTE:
+			return cmp <= 0
+		case bql.GT:
+			return cmp > 0
+		default:
+			return cmp >= 0
+		}
+	case bql.TILDE:
+		ls, lok := l.(string)
+		rs, rok := r.(string)
+		if !lok || !rok {
+			return false
+		}
+		matched, err := regexp.MatchString(rs, ls)
+		return err == nil && matched
+	case bql.IN:
+		elem, ok := l.(string)
+		if !ok {
+			return false
+		}
+		set, ok := r.(Set)
+		if !ok {
+			return false
+		}
+		return set.Contains(elem)
+	case bql.PLUS, bql.MINUS, bql.ASTERISK, bql.SLASH:
+		return c.evalArithmetic(l, r)
+	}
+	return nil
+}
+
+func (c *cBinary) evalArithmetic(l, r any) any {
+	if li, lok := l.(int64); lok {
+		if ri, rok := r.(int64); rok && c.op != bql.SLASH {
+			switch c.op {
+			case bql.PLUS:
+				return li + ri
+			case bql.MINUS:
+				return li - ri
+			case bql.ASTERISK:
+				return li * ri
+			}
+		}
+	}
+	ld, lok := asDecimal(l)
+	rd, rok := asDecimal(r)
+	if !lok || !rok {
+		return nil
+	}
+	switch c.op {
+	case bql.PLUS:
+		return ld.Add(rd)
+	case bql.MINUS:
+		return ld.Sub(rd)
+	case bql.ASTERISK:
+		return ld.Mul(rd)
+	case bql.SLASH:
+		if rd.IsZero() {
+			return nil
+		}
+		return ld.Div(rd)
+	}
+	return nil
+}

--- a/query/compile.go
+++ b/query/compile.go
@@ -253,17 +253,19 @@ func (c *compiler) resolvePivotBy(sel *bql.Select, compiled *Compiled) error {
 // hidden targets.
 func (c *compiler) resolveTargetRef(item bql.Expr, compiled *Compiled, allowAgg bool) (int, error) {
 	if lit, ok := item.(*bql.Int); ok {
-		visible := 0
-		for _, target := range compiled.Targets {
-			if !target.Hidden {
-				visible++
+		// Walk the visible targets to the 1-based index; no int64-to-int
+		// narrowing needed.
+		var n int64
+		for i, target := range compiled.Targets {
+			if target.Hidden {
+				continue
+			}
+			n++
+			if n == lit.Value {
+				return i, nil
 			}
 		}
-		// Range-check the int64 literal before narrowing to int.
-		if lit.Value < 1 || lit.Value > int64(visible) {
-			return 0, compileErrorf(item, "Invalid GROUP-BY column index %d", lit.Value)
-		}
-		return int(lit.Value) - 1, nil
+		return 0, compileErrorf(item, "Invalid GROUP-BY column index %d", lit.Value)
 	}
 
 	if ident, ok := item.(*bql.Ident); ok {

--- a/query/compile.go
+++ b/query/compile.go
@@ -253,17 +253,17 @@ func (c *compiler) resolvePivotBy(sel *bql.Select, compiled *Compiled) error {
 // hidden targets.
 func (c *compiler) resolveTargetRef(item bql.Expr, compiled *Compiled, allowAgg bool) (int, error) {
 	if lit, ok := item.(*bql.Int); ok {
-		idx := int(lit.Value)
 		visible := 0
 		for _, target := range compiled.Targets {
 			if !target.Hidden {
 				visible++
 			}
 		}
-		if idx < 1 || idx > visible {
-			return 0, compileErrorf(item, "Invalid GROUP-BY column index %d", idx)
+		// Range-check the int64 literal before narrowing to int.
+		if lit.Value < 1 || lit.Value > int64(visible) {
+			return 0, compileErrorf(item, "Invalid GROUP-BY column index %d", lit.Value)
 		}
-		return idx - 1, nil
+		return int(lit.Value) - 1, nil
 	}
 
 	if ident, ok := item.(*bql.Ident); ok {

--- a/query/compile_test.go
+++ b/query/compile_test.go
@@ -1,0 +1,259 @@
+package query
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/config"
+	"github.com/robinvdvleuten/beancount/ledger"
+	"github.com/robinvdvleuten/beancount/parser"
+	"github.com/robinvdvleuten/beancount/query/bql"
+)
+
+const testLedger = `
+2014-01-01 open Assets:Checking USD
+2014-01-01 open Assets:Invest HOOL
+2014-01-01 open Income:Salary USD
+2014-01-01 open Expenses:Food USD
+2014-01-01 open Equity:Opening-Balances USD
+
+2014-01-02 * "Opening"
+  Assets:Checking  1000.00 USD
+  Equity:Opening-Balances
+
+2014-02-03 * "Acme" "Salary" #job ^ticket
+  Assets:Checking  2500.00 USD
+  Income:Salary
+
+2014-03-05 * "Cafe" "Coffee" #food
+  meta: "posting-level"
+  Expenses:Food  4.50 USD
+  Assets:Checking
+
+2014-04-01 * "Broker" "Buy HOOL"
+  Assets:Invest  10 HOOL {500.00 USD}
+  Assets:Checking
+
+2014-05-01 price HOOL 520.00 USD
+`
+
+// newTestContext parses and processes the test ledger into a query Context
+// and the processed directive tree.
+func newTestContext(t *testing.T) (*Context, *ast.AST) {
+	t.Helper()
+	return newContextFromSource(t, testLedger)
+}
+
+func newContextFromSource(t *testing.T, source string) (*Context, *ast.AST) {
+	t.Helper()
+
+	tree, err := parser.ParseBytesWithFilename(context.Background(), "test.beancount", []byte(source))
+	assert.NoError(t, err)
+
+	l := ledger.New()
+	assert.NoError(t, l.Process(context.Background(), tree))
+
+	cfg, err := config.FromAST(tree)
+	assert.NoError(t, err)
+
+	return &Context{Ledger: l, Config: cfg}, tree
+}
+
+func mustCompile(t *testing.T, ctx *Context, query string) *Compiled {
+	t.Helper()
+	stmt, err := bql.Parse(query)
+	assert.NoError(t, err)
+	compiled, err := Compile(ctx, stmt)
+	assert.NoError(t, err)
+	return compiled
+}
+
+func compileError(t *testing.T, ctx *Context, query string) error {
+	t.Helper()
+	stmt, err := bql.Parse(query)
+	assert.NoError(t, err)
+	_, err = Compile(ctx, stmt)
+	assert.Error(t, err)
+	return err
+}
+
+func TestCompileWildcard(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	compiled := mustCompile(t, ctx, "SELECT *")
+
+	names := make([]string, len(compiled.Targets))
+	for i, target := range compiled.Targets {
+		names[i] = target.Name
+	}
+	assert.Equal(t, []string{"date", "flag", "payee", "narration", "position"}, names)
+}
+
+func TestCompileTargetNaming(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	for _, tt := range []struct {
+		query string
+		name  string
+	}{
+		{"SELECT account", "account"},
+		{"SELECT account AS acc", "acc"},
+		{"SELECT sum(position)", "sum_position"},
+		{"SELECT sum(cost(position))", "sum_cost_position"},
+		{"SELECT year(date)", "year_date"},
+		{"SELECT 'lit'", "clit"},
+		{"SELECT 42", "c42"},
+		{"SELECT 3.14", "c3_14"},
+		{"SELECT number + 1", "add_number_c1"},
+		{"SELECT number - 1", "sub_number_c1"},
+		{"SELECT number * 2", "mul_number_c2"},
+		{"SELECT number / 2", "div_number_c2"},
+		{"SELECT str(2 = 2)", "str_equal_c2_c2"},
+	} {
+		compiled := mustCompile(t, ctx, tt.query)
+		assert.Equal(t, tt.name, compiled.Targets[0].Name, tt.query)
+	}
+}
+
+func TestCompileTargetTypes(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	for _, tt := range []struct {
+		query string
+		typ   DType
+	}{
+		{"SELECT account", TString},
+		{"SELECT date", TDate},
+		{"SELECT position", TPosition},
+		{"SELECT balance", TInventory},
+		{"SELECT number", TDecimal},
+		{"SELECT lineno", TInt},
+		{"SELECT tags", TSet},
+		{"SELECT price", TAmount},
+		{"SELECT sum(position)", TInventory},
+		{"SELECT sum(number)", TDecimal},
+		{"SELECT count(date)", TInt},
+		{"SELECT first(account)", TString},
+		{"SELECT year(date)", TInt},
+		{"SELECT number / 2", TDecimal},
+		{"SELECT 1 + 2", TInt},
+	} {
+		compiled := mustCompile(t, ctx, tt.query)
+		assert.Equal(t, tt.typ, compiled.Targets[0].Type, tt.query)
+	}
+}
+
+func TestCompileInvalidColumn(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT bogus")
+	assert.Equal(t, "Invalid column name 'bogus' in targets/column context.", err.Error())
+}
+
+func TestCompileInvalidFunction(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT bogusfn(date)")
+	assert.Equal(t, "Invalid function 'bogusfn(date)' in targets/column context.", err.Error())
+}
+
+func TestCompileImplicitGroupBy(t *testing.T) {
+	// An aggregate query without GROUP BY implicitly groups by all
+	// non-aggregate targets (official behavior).
+	ctx, _ := newTestContext(t)
+	compiled := mustCompile(t, ctx, "SELECT account, sum(position)")
+
+	assert.True(t, compiled.HasAgg)
+	assert.Equal(t, []int{0}, compiled.GroupBy)
+}
+
+func TestCompileGroupByCoverage(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT date GROUP BY narration")
+	assert.Equal(t,
+		`All non-aggregates must be covered by GROUP-BY clause in aggregate query; the following targets are missing: "date".`,
+		err.Error())
+}
+
+func TestCompileGroupByIndexAndAlias(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	compiled := mustCompile(t, ctx, "SELECT account, sum(position) GROUP BY 1")
+	assert.Equal(t, []int{0}, compiled.GroupBy)
+
+	compiled = mustCompile(t, ctx, "SELECT account AS acc, sum(position) GROUP BY acc")
+	assert.Equal(t, []int{0}, compiled.GroupBy)
+
+	compiled = mustCompile(t, ctx, "SELECT year(date) AS y, count(date) GROUP BY y")
+	assert.Equal(t, []int{0}, compiled.GroupBy)
+}
+
+func TestCompileGroupByIndexOutOfRange(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT account, sum(position) GROUP BY 5")
+	assert.Contains(t, err.Error(), "Invalid GROUP-BY column index 5")
+}
+
+func TestCompileGroupByAggregate(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT account, sum(position) GROUP BY 2")
+	assert.Equal(t, "GROUP-BY expressions may not be aggregates.", err.Error())
+}
+
+func TestCompileOrderByHiddenTarget(t *testing.T) {
+	// ORDER BY on a column not in the targets appends a hidden target.
+	ctx, _ := newTestContext(t)
+	compiled := mustCompile(t, ctx, "SELECT account ORDER BY date")
+
+	assert.Equal(t, 2, len(compiled.Targets))
+	assert.True(t, compiled.Targets[1].Hidden)
+	assert.Equal(t, []int{1}, compiled.OrderBy)
+}
+
+func TestCompileOrderByMatchesTarget(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	compiled := mustCompile(t, ctx, "SELECT account, sum(position) GROUP BY account ORDER BY sum(position) DESC")
+
+	assert.Equal(t, 2, len(compiled.Targets))
+	assert.Equal(t, []int{1}, compiled.OrderBy)
+	assert.True(t, compiled.OrderDesc)
+}
+
+func TestCompileAggregateInWhere(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT account WHERE sum(number) > 0")
+	assert.Contains(t, err.Error(), "Aggregates are disallowed")
+}
+
+func TestCompileFromUsesEntryEnvironment(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	// account is a posting column, not available in the FROM filter.
+	err := compileError(t, ctx, "SELECT date FROM account ~ 'Assets'")
+	assert.Contains(t, err.Error(), "Invalid column name 'account'")
+
+	// has_account is the FROM-environment predicate for that.
+	mustCompile(t, ctx, "SELECT date FROM has_account('Assets')")
+}
+
+func TestCompileFunctionOverloads(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	assert.Equal(t, TAmount, mustCompile(t, ctx, "SELECT units(position)").Targets[0].Type)
+	assert.Equal(t, TInventory, mustCompile(t, ctx, "SELECT units(sum(position))").Targets[0].Type)
+	assert.Equal(t, TAmount, mustCompile(t, ctx, "SELECT convert(price, 'USD')").Targets[0].Type)
+	assert.Equal(t, TDecimal, mustCompile(t, ctx, "SELECT safediv(number, 2)").Targets[0].Type)
+}
+
+func TestCompileInvalidOverload(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	err := compileError(t, ctx, "SELECT units(account)")
+	assert.True(t, strings.HasPrefix(err.Error(), "Invalid function 'units(str)'"), err.Error())
+}
+
+func TestCompileDistinctAndLimit(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	compiled := mustCompile(t, ctx, "SELECT DISTINCT account LIMIT 5")
+	assert.True(t, compiled.Distinct)
+	assert.Equal(t, int64(5), *compiled.Limit)
+}

--- a/query/desugar.go
+++ b/query/desugar.go
@@ -1,0 +1,138 @@
+package query
+
+import (
+	"context"
+	"io"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/formatter"
+	"github.com/robinvdvleuten/beancount/query/bql"
+)
+
+// Desugar rewrites the BALANCES and JOURNAL shortcut statements into the
+// SELECT statements the official tool expands them to. Other statements are
+// returned unchanged.
+func Desugar(stmt bql.Statement) bql.Statement {
+	switch node := stmt.(type) {
+	case *bql.Balances:
+		return desugarBalances(node)
+	case *bql.Journal:
+		return desugarJournal(node)
+	}
+	return stmt
+}
+
+// desugarBalances expands BALANCES [AT fn] into
+//
+//	SELECT account, sum([fn(]position[)])
+//	GROUP BY account ORDER BY account_sortkey(account)
+func desugarBalances(b *bql.Balances) *bql.Select {
+	account := &bql.Ident{Name: "account"}
+	return &bql.Select{
+		Targets: []bql.Target{
+			{Expr: account},
+			{Expr: call("sum", summarize(b.Summary, &bql.Ident{Name: "position"}))},
+		},
+		From:    b.From,
+		GroupBy: []bql.Expr{account},
+		OrderBy: []bql.Expr{call("account_sortkey", account)},
+	}
+}
+
+// desugarJournal expands JOURNAL [account] [AT fn] into
+//
+//	SELECT date, flag, maxwidth(payee, 48), maxwidth(narration, 80),
+//	       account, [fn(]position[)], [fn(]balance[)]
+//	[WHERE account ~ "<account>"]
+func desugarJournal(j *bql.Journal) *bql.Select {
+	sel := &bql.Select{
+		Targets: []bql.Target{
+			{Expr: &bql.Ident{Name: "date"}},
+			{Expr: &bql.Ident{Name: "flag"}},
+			{Expr: call("maxwidth", &bql.Ident{Name: "payee"}, &bql.Int{Value: 48})},
+			{Expr: call("maxwidth", &bql.Ident{Name: "narration"}, &bql.Int{Value: 80})},
+			{Expr: &bql.Ident{Name: "account"}},
+			{Expr: summarize(j.Summary, &bql.Ident{Name: "position"})},
+			{Expr: summarize(j.Summary, &bql.Ident{Name: "balance"})},
+		},
+		From: j.From,
+	}
+	if j.Account != "" {
+		sel.Where = &bql.Binary{
+			Op: bql.TILDE,
+			L:  &bql.Ident{Name: "account"},
+			R:  &bql.Str{Value: j.Account},
+		}
+	}
+	return sel
+}
+
+func call(name string, args ...bql.Expr) *bql.Call {
+	return &bql.Call{Func: name, Args: args}
+}
+
+// summarize wraps an expression in the AT summary function when present.
+func summarize(summary string, expr bql.Expr) bql.Expr {
+	if summary == "" {
+		return expr
+	}
+	return call(summary, expr)
+}
+
+// CompiledPrint is a compiled PRINT statement: just its entry filter.
+type CompiledPrint struct {
+	From *CompiledFrom
+}
+
+// CompilePrint compiles a PRINT statement's FROM clause.
+func CompilePrint(ctx *Context, p *bql.Print) (*CompiledPrint, error) {
+	compiled := &CompiledPrint{}
+	if p.From != nil {
+		from := &CompiledFrom{
+			OpenOn:  p.From.OpenOn,
+			Close:   p.From.Close,
+			CloseOn: p.From.CloseOn,
+			Clear:   p.From.Clear,
+		}
+		if p.From.Expr != nil {
+			c := &compiler{ctx: ctx, env: filterEnv}
+			expr, err := c.compileExpr(p.From.Expr, false)
+			if err != nil {
+				return nil, err
+			}
+			from.Expr = expr
+		}
+		compiled.From = from
+	}
+	return compiled, nil
+}
+
+// ExecutePrint renders the directives passing the FROM filter as beancount
+// text. Transactions are preceded by a blank line, matching the official
+// printer's spacing.
+func ExecutePrint(ctx context.Context, qctx *Context, tree *ast.AST, compiled *CompiledPrint, w io.Writer) error {
+	entries := []ast.Directive(tree.Directives)
+	if compiled.From != nil {
+		entries = applyFromTransforms(qctx, entries, compiled.From)
+	}
+
+	f := formatter.New()
+	for _, entry := range entries {
+		if compiled.From != nil && compiled.From.Expr != nil {
+			row := &Row{Ctx: qctx, Entry: entry}
+			if !truthy(compiled.From.Expr.eval(row)) {
+				continue
+			}
+		}
+		if _, ok := entry.(*ast.Transaction); ok {
+			if _, err := io.WriteString(w, "\n"); err != nil {
+				return err
+			}
+		}
+		single := &ast.AST{Directives: ast.Directives{entry}}
+		if err := f.Format(ctx, single, nil, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/query/env.go
+++ b/query/env.go
@@ -1,0 +1,305 @@
+package query
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/config"
+	"github.com/robinvdvleuten/beancount/ledger"
+	"github.com/shopspring/decimal"
+)
+
+// Context carries the processed ledger data a query executes against.
+type Context struct {
+	Ledger *ledger.Ledger
+	Config *config.Config
+}
+
+// Row is the evaluation context for one data row. In the FROM (entry)
+// environment only Entry is set; in the posting environment Txn and Posting
+// identify the flattened posting row. Balance is the running per-account
+// inventory maintained by the executor. AggValues holds finalized aggregate
+// results while group targets are evaluated.
+type Row struct {
+	Ctx       *Context
+	Entry     ast.Directive
+	Txn       *ast.Transaction
+	Posting   *ast.Posting
+	Balance   *Inventory
+	AggValues []any
+	// CostDate is the effective cost-basis date for this posting: lot
+	// reductions inherit the matched lot's date (official booking behavior),
+	// everything else gets the transaction date.
+	CostDate *ast.Date
+}
+
+// costDate returns the effective cost date, defaulting to the entry date.
+func (row *Row) costDate() *ast.Date {
+	if row.CostDate != nil {
+		return row.CostDate
+	}
+	return row.Entry.Date()
+}
+
+// columnDef declares a column available in an environment: its result type
+// and how to evaluate it for a row.
+type columnDef struct {
+	typ  DType
+	eval func(row *Row) any
+}
+
+// wildcardColumns is the column list SELECT * expands to, matching the
+// official targets environment.
+var wildcardColumns = []string{"date", "flag", "payee", "narration", "position"}
+
+// entryColumns is the FROM environment: columns on directives.
+var entryColumns = map[string]*columnDef{
+	"date":        {TDate, func(row *Row) any { return row.Entry.Date() }},
+	"year":        {TInt, func(row *Row) any { return int64(row.Entry.Date().Year()) }},
+	"month":       {TInt, func(row *Row) any { return int64(row.Entry.Date().Month()) }},
+	"day":         {TInt, func(row *Row) any { return int64(row.Entry.Date().Day()) }},
+	"type":        {TString, func(row *Row) any { return string(row.Entry.Kind()) }},
+	"filename":    {TString, func(row *Row) any { return row.Entry.Position().Filename }},
+	"lineno":      {TInt, func(row *Row) any { return int64(row.Entry.Position().Line) }},
+	"id":          {TString, func(row *Row) any { return entryID(row.Entry) }},
+	"flag":        {TString, txnColumn(func(txn *ast.Transaction) any { return txn.Flag })},
+	"payee":       {TString, txnColumn(func(txn *ast.Transaction) any { return txn.Payee.String() })},
+	"narration":   {TString, txnColumn(func(txn *ast.Transaction) any { return txn.Narration.String() })},
+	"description": {TString, txnColumn(descriptionValue)},
+	"tags":        {TSet, txnColumn(func(txn *ast.Transaction) any { return tagSet(txn) })},
+	"links":       {TSet, txnColumn(func(txn *ast.Transaction) any { return linkSet(txn) })},
+}
+
+// postingColumns is the targets/WHERE environment: columns on posting rows.
+var postingColumns = map[string]*columnDef{
+	"account":       {TString, func(row *Row) any { return string(row.Posting.Account) }},
+	"position":      {TPosition, func(row *Row) any { return postingPosition(row.Posting, row.costDate()) }},
+	"change":        {TPosition, func(row *Row) any { return postingPosition(row.Posting, row.costDate()) }},
+	"balance":       {TInventory, func(row *Row) any { return row.Balance }},
+	"number":        {TDecimal, func(row *Row) any { return postingNumber(row.Posting) }},
+	"currency":      {TString, func(row *Row) any { return postingCurrency(row.Posting) }},
+	"cost_number":   {TDecimal, costColumn(func(c *Cost) any { return c.Number })},
+	"cost_currency": {TString, costColumn(func(c *Cost) any { return c.Currency })},
+	"cost_date":     {TDate, costColumn(func(c *Cost) any { return c.Date })},
+	"cost_label":    {TString, costColumn(func(c *Cost) any { return c.Label })},
+	"price":         {TAmount, func(row *Row) any { return postingPrice(row.Posting) }},
+	"weight":        {TAmount, func(row *Row) any { return postingWeight(row.Posting, row.Entry.Date()) }},
+	"posting_flag":  {TString, func(row *Row) any { return row.Posting.Flag }},
+	"other_accounts": {TSet, func(row *Row) any {
+		others := make(Set)
+		for _, p := range row.Txn.Postings {
+			if p.Account != row.Posting.Account {
+				others[string(p.Account)] = struct{}{}
+			}
+		}
+		return others
+	}},
+	"location": {TString, func(row *Row) any {
+		pos := row.Posting.Position()
+		return fmt.Sprintf("%s:%d:", pos.Filename, pos.Line)
+	}},
+
+	// Transaction-level context, shared with the entry environment.
+	"date":        {TDate, func(row *Row) any { return row.Entry.Date() }},
+	"year":        {TInt, func(row *Row) any { return int64(row.Entry.Date().Year()) }},
+	"month":       {TInt, func(row *Row) any { return int64(row.Entry.Date().Month()) }},
+	"day":         {TInt, func(row *Row) any { return int64(row.Entry.Date().Day()) }},
+	"type":        {TString, func(row *Row) any { return string(row.Entry.Kind()) }},
+	"filename":    {TString, func(row *Row) any { return row.Entry.Position().Filename }},
+	"lineno":      {TInt, func(row *Row) any { return int64(row.Entry.Position().Line) }},
+	"id":          {TString, func(row *Row) any { return entryID(row.Entry) }},
+	"flag":        {TString, func(row *Row) any { return row.Txn.Flag }},
+	"payee":       {TString, func(row *Row) any { return row.Txn.Payee.String() }},
+	"narration":   {TString, func(row *Row) any { return row.Txn.Narration.String() }},
+	"description": {TString, func(row *Row) any { return descriptionValue(row.Txn) }},
+	"tags":        {TSet, func(row *Row) any { return tagSet(row.Txn) }},
+	"links":       {TSet, func(row *Row) any { return linkSet(row.Txn) }},
+}
+
+// environment names a column set for compilation and error messages.
+type environment struct {
+	columns map[string]*columnDef
+	context string
+}
+
+var (
+	targetsEnv = &environment{columns: postingColumns, context: "targets/column context"}
+	filterEnv  = &environment{columns: entryColumns, context: "filter context"}
+)
+
+// txnColumn wraps a transaction accessor into an entry-environment column
+// that yields NULL for non-transaction directives.
+func txnColumn(eval func(txn *ast.Transaction) any) func(row *Row) any {
+	return func(row *Row) any {
+		if txn, ok := row.Entry.(*ast.Transaction); ok {
+			return eval(txn)
+		}
+		return nil
+	}
+}
+
+// costColumn wraps a cost accessor into a column that yields NULL for
+// postings without a cost basis.
+func costColumn(eval func(c *Cost) any) func(row *Row) any {
+	return func(row *Row) any {
+		position := postingPosition(row.Posting, row.costDate())
+		if position == nil || position.Cost == nil {
+			return nil
+		}
+		return eval(position.Cost)
+	}
+}
+
+func descriptionValue(txn *ast.Transaction) any {
+	payee := txn.Payee.String()
+	narration := txn.Narration.String()
+	if payee != "" && narration != "" {
+		return payee + " | " + narration
+	}
+	if payee != "" {
+		return payee
+	}
+	return narration
+}
+
+func tagSet(txn *ast.Transaction) Set {
+	set := make(Set, len(txn.Tags))
+	for _, tag := range txn.Tags {
+		set[string(tag)] = struct{}{}
+	}
+	return set
+}
+
+func linkSet(txn *ast.Transaction) Set {
+	set := make(Set, len(txn.Links))
+	for _, link := range txn.Links {
+		set[string(link)] = struct{}{}
+	}
+	return set
+}
+
+// entryID returns a unique, stable id for a directive. The official
+// implementation hashes the full directive contents; we hash the source
+// location, which is equally unique and stable but yields different digests
+// (documented in testdata/compliance/KNOWN_GAPS.md).
+func entryID(entry ast.Directive) string {
+	pos := entry.Position()
+	sum := md5.Sum(fmt.Appendf(nil, "%s:%d", pos.Filename, pos.Line))
+	return hex.EncodeToString(sum[:])
+}
+
+// postingPosition converts an AST posting into a query Position with a
+// normalized per-unit cost. The ledger resolves interpolated amounts and
+// inferred costs in place, but total costs ({{...}}) keep their original
+// form in the AST, so per-unit normalization happens here. Cost bases
+// without an explicit date are stamped with the transaction date, matching
+// official booking (the date shows in cost_date but not in rendered
+// positions).
+func postingPosition(posting *ast.Posting, entryDate *ast.Date) *Position {
+	if posting.Amount == nil {
+		return nil
+	}
+	number, err := ledger.ParseAmount(posting.Amount)
+	if err != nil {
+		return nil
+	}
+	position := &Position{Units: Amount{Number: number, Currency: posting.Amount.Currency}}
+
+	if posting.Cost != nil {
+		cost := &Cost{Date: posting.Cost.Date, Label: posting.Cost.Label}
+		if cost.Date == nil {
+			cost.Date = entryDate
+		}
+		costAmount := posting.Cost.Amount
+		if costAmount == nil {
+			costAmount = posting.Cost.Total
+		}
+		if costAmount != nil {
+			costNumber, err := ledger.ParseAmount(costAmount)
+			if err != nil {
+				return nil
+			}
+			if posting.Cost.IsTotal || posting.Cost.Total != nil {
+				if !number.IsZero() {
+					costNumber = costNumber.Div(number.Abs())
+				}
+			}
+			cost.Number = costNumber
+			cost.Currency = costAmount.Currency
+		}
+		position.Cost = cost
+	}
+	return position
+}
+
+func postingNumber(posting *ast.Posting) any {
+	if posting.Amount == nil {
+		return nil
+	}
+	number, err := ledger.ParseAmount(posting.Amount)
+	if err != nil {
+		return nil
+	}
+	return number
+}
+
+func postingCurrency(posting *ast.Posting) any {
+	if posting.Amount == nil {
+		return nil
+	}
+	return posting.Amount.Currency
+}
+
+// postingPrice returns the per-unit price attached to a posting. Total
+// prices (@@) are normalized to per-unit, matching the official booking
+// behavior.
+func postingPrice(posting *ast.Posting) any {
+	if posting.Price == nil {
+		return nil
+	}
+	number, err := ledger.ParseAmount(posting.Price)
+	if err != nil {
+		return nil
+	}
+	if posting.PriceTotal {
+		units, err := ledger.ParseAmount(posting.Amount)
+		if err != nil || units.IsZero() {
+			return nil
+		}
+		number = number.Div(units.Abs())
+	}
+	return &Amount{Number: number, Currency: posting.Price.Currency}
+}
+
+// postingWeight computes the booking weight of a posting: units at cost if a
+// cost basis is attached, converted at price if a price is attached, and the
+// plain units otherwise.
+func postingWeight(posting *ast.Posting, entryDate *ast.Date) any {
+	position := postingPosition(posting, entryDate)
+	if position == nil {
+		return nil
+	}
+	if position.Cost != nil {
+		return &Amount{
+			Number:   position.Units.Number.Mul(position.Cost.Number),
+			Currency: position.Cost.Currency,
+		}
+	}
+	if price, ok := postingPrice(posting).(*Amount); ok && price != nil {
+		return &Amount{
+			Number:   position.Units.Number.Mul(price.Number),
+			Currency: price.Currency,
+		}
+	}
+	return &position.Units
+}
+
+// priceLookup fetches a conversion rate from the ledger price graph.
+func priceLookup(ctx *Context, date *ast.Date, from, to string) (decimal.Decimal, bool) {
+	if ctx == nil || ctx.Ledger == nil {
+		return decimal.Decimal{}, false
+	}
+	return ctx.Ledger.GetPrice(date, from, to)
+}

--- a/query/exec.go
+++ b/query/exec.go
@@ -1,0 +1,261 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/telemetry"
+)
+
+// Result is an executed query: a header of visible columns and the result
+// rows, with one value per column.
+type Result struct {
+	Columns []ResultColumn
+	Rows    [][]any
+}
+
+// ResultColumn describes one output column for the renderers.
+type ResultColumn struct {
+	Name string
+	Type DType
+}
+
+// Execute runs a compiled query over the processed directive stream. The
+// tree must have been processed by the ledger so posting amounts and costs
+// are interpolated.
+func Execute(ctx context.Context, qctx *Context, tree *ast.AST, compiled *Compiled) (*Result, error) {
+	timer := telemetry.FromContext(ctx).Start("query.execute")
+	defer timer.End()
+
+	if len(compiled.PivotBy) > 0 {
+		// Official bean-query 2.x parses but rejects PIVOT BY; match its
+		// error message exactly, punctuation included.
+		return nil, errors.New("The PIVOT BY clause is not supported yet.") //nolint:staticcheck // official message parity
+	}
+
+	rows, err := generateRows(ctx, qctx, tree, compiled)
+	if err != nil {
+		return nil, err
+	}
+
+	var output [][]any
+	if compiled.HasAgg || len(compiled.GroupBy) > 0 {
+		output = executeGrouped(rows, compiled)
+	} else {
+		output = make([][]any, 0, len(rows))
+		for _, row := range rows {
+			output = append(output, evalTargets(row, compiled))
+		}
+	}
+
+	output = orderRows(output, compiled)
+	output = projectVisible(output, compiled)
+	if compiled.Distinct {
+		output = distinctRows(output)
+	}
+	if compiled.Limit != nil && int64(len(output)) > *compiled.Limit {
+		output = output[:*compiled.Limit]
+	}
+
+	result := &Result{Rows: output}
+	for _, target := range compiled.Targets {
+		if !target.Hidden {
+			result.Columns = append(result.Columns, ResultColumn{Name: target.Name, Type: target.Type})
+		}
+	}
+	return result, nil
+}
+
+// generateRows applies the FROM filter to the directive stream and flattens
+// the surviving transactions into posting rows. Per-account inventories are
+// tracked for booking-style lot-date inheritance; the balance column is a
+// single running inventory over the rows that survive WHERE, matching the
+// official executor.
+func generateRows(ctx context.Context, qctx *Context, tree *ast.AST, compiled *Compiled) ([]*Row, error) {
+	entries := []ast.Directive(tree.Directives)
+	if compiled.From != nil {
+		entries = applyFromTransforms(qctx, entries, compiled.From)
+	}
+
+	var rows []*Row
+	accounts := make(map[string]*Inventory)
+	running := NewInventory()
+
+	for i, entry := range entries {
+		if i%1024 == 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+		}
+
+		entryRow := &Row{Ctx: qctx, Entry: entry}
+		if compiled.From != nil && compiled.From.Expr != nil {
+			if !truthy(compiled.From.Expr.eval(entryRow)) {
+				continue
+			}
+		}
+
+		txn, ok := entry.(*ast.Transaction)
+		if !ok {
+			continue
+		}
+
+		for _, posting := range txn.Postings {
+			row := &Row{Ctx: qctx, Entry: entry, Txn: txn, Posting: posting}
+
+			account := string(posting.Account)
+			inventory, ok := accounts[account]
+			if !ok {
+				inventory = NewInventory()
+				accounts[account] = inventory
+			}
+			position := postingPosition(posting, entry.Date())
+			if position != nil {
+				// Reductions without an explicit cost date inherit the
+				// matched lot's date, like official booking, so lots merge
+				// when summed.
+				if position.Cost != nil && (posting.Cost == nil || posting.Cost.Date == nil) {
+					if inherited := inventory.matchLotDate(position); inherited != nil {
+						row.CostDate = inherited
+						position.Cost.Date = inherited
+					}
+				}
+				inventory.AddPosition(position)
+			}
+
+			if compiled.Where != nil && !truthy(compiled.Where.eval(row)) {
+				continue
+			}
+			if compiled.UsesBalance {
+				if position != nil {
+					running.AddPosition(position)
+				}
+				row.Balance = running.Copy()
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows, nil
+}
+
+// evalTargets evaluates every target (visible and hidden) for a row.
+func evalTargets(row *Row, compiled *Compiled) []any {
+	values := make([]any, len(compiled.Targets))
+	for i, target := range compiled.Targets {
+		values[i] = target.expr.eval(row)
+	}
+	return values
+}
+
+// group accumulates aggregate state for one distinct set of group keys.
+type group struct {
+	rep  *Row // representative row for evaluating group-key targets
+	accs []accumulator
+}
+
+// executeGrouped hash-aggregates rows by the GROUP-BY targets and evaluates
+// the full target list once per group, in first-seen order.
+func executeGrouped(rows []*Row, compiled *Compiled) [][]any {
+	groups := make(map[string]*group)
+	var order []string
+
+	for _, row := range rows {
+		var key strings.Builder
+		for _, idx := range compiled.GroupBy {
+			key.WriteString(valueString(compiled.Targets[idx].expr.eval(row)))
+			key.WriteByte('\x00')
+		}
+		k := key.String()
+
+		g, ok := groups[k]
+		if !ok {
+			g = &group{rep: row, accs: make([]accumulator, len(compiled.Aggs))}
+			for i, agg := range compiled.Aggs {
+				g.accs[i] = agg.def.new(agg.arg.typ())
+			}
+			groups[k] = g
+			order = append(order, k)
+		}
+		for i, agg := range compiled.Aggs {
+			g.accs[i].update(agg.arg.eval(row))
+		}
+	}
+
+	output := make([][]any, 0, len(order))
+	for _, k := range order {
+		g := groups[k]
+		g.rep.AggValues = make([]any, len(compiled.Aggs))
+		for i, acc := range g.accs {
+			g.rep.AggValues[i] = acc.finalize()
+		}
+		output = append(output, evalTargets(g.rep, compiled))
+	}
+	return output
+}
+
+// orderRows sorts rows by the ORDER-BY target values. The sort is stable so
+// ties keep their natural (ledger) order, and a single direction applies to
+// the whole key list, matching the official grammar.
+func orderRows(output [][]any, compiled *Compiled) [][]any {
+	if len(compiled.OrderBy) == 0 {
+		return output
+	}
+	slices.SortStableFunc(output, func(a, b []any) int {
+		for _, idx := range compiled.OrderBy {
+			if cmp := compareValues(a[idx], b[idx]); cmp != 0 {
+				if compiled.OrderDesc {
+					return -cmp
+				}
+				return cmp
+			}
+		}
+		return 0
+	})
+	return output
+}
+
+// projectVisible strips hidden (group/order key) columns from the output.
+func projectVisible(output [][]any, compiled *Compiled) [][]any {
+	visible := make([]int, 0, len(compiled.Targets))
+	for i, target := range compiled.Targets {
+		if !target.Hidden {
+			visible = append(visible, i)
+		}
+	}
+	if len(visible) == len(compiled.Targets) {
+		return output
+	}
+	projected := make([][]any, len(output))
+	for i, row := range output {
+		values := make([]any, len(visible))
+		for j, idx := range visible {
+			values[j] = row[idx]
+		}
+		projected[i] = values
+	}
+	return projected
+}
+
+// distinctRows removes duplicate rows, keeping first occurrences.
+func distinctRows(output [][]any) [][]any {
+	seen := make(map[string]bool, len(output))
+	result := output[:0]
+	for _, row := range output {
+		var key strings.Builder
+		for _, v := range row {
+			key.WriteString(valueString(v))
+			key.WriteByte('\x00')
+		}
+		k := key.String()
+		if !seen[k] {
+			seen[k] = true
+			result = append(result, row)
+		}
+	}
+	return result
+}

--- a/query/exec_test.go
+++ b/query/exec_test.go
@@ -1,0 +1,193 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/query/bql"
+	"github.com/shopspring/decimal"
+)
+
+// runQuery compiles and executes a query against the shared test ledger.
+func runQuery(t *testing.T, query string) *Result {
+	t.Helper()
+	ctx, tree := newTestContext(t)
+	return runQueryOn(t, ctx, tree, query)
+}
+
+func runQueryOn(t *testing.T, ctx *Context, tree *ast.AST, query string) *Result {
+	t.Helper()
+	stmt, err := bql.Parse(query)
+	assert.NoError(t, err)
+	compiled, err := Compile(ctx, stmt)
+	assert.NoError(t, err)
+	result, err := Execute(context.Background(), ctx, tree, compiled)
+	assert.NoError(t, err)
+	return result
+}
+
+func TestExecuteSimpleSelect(t *testing.T) {
+	result := runQuery(t, "SELECT date, account, number")
+
+	// 4 transactions with 2 postings each.
+	assert.Equal(t, 8, len(result.Rows))
+	assert.Equal(t, "date", result.Columns[0].Name)
+	assert.Equal(t, "2014-01-02", valueString(result.Rows[0][0]))
+	assert.Equal(t, "Assets:Checking", result.Rows[0][1].(string))
+	assert.Equal(t, "1000", result.Rows[0][2].(decimal.Decimal).String())
+}
+
+func TestExecuteInterpolatedAmounts(t *testing.T) {
+	// The second posting of the opening transaction has no explicit amount;
+	// the ledger interpolates it.
+	result := runQuery(t, "SELECT account, number WHERE account = 'Equity:Opening-Balances'")
+
+	assert.Equal(t, 1, len(result.Rows))
+	assert.Equal(t, "-1000", result.Rows[0][1].(decimal.Decimal).String())
+}
+
+func TestExecuteWhere(t *testing.T) {
+	result := runQuery(t, "SELECT account WHERE number > 100")
+	assert.Equal(t, 2, len(result.Rows))
+}
+
+func TestExecuteFromFiltersEntries(t *testing.T) {
+	result := runQuery(t, "SELECT date, account FROM month = 2")
+	assert.Equal(t, 2, len(result.Rows))
+}
+
+func TestExecuteGroupBySum(t *testing.T) {
+	result := runQuery(t, "SELECT account, sum(position) GROUP BY account ORDER BY account")
+
+	assert.Equal(t, 5, len(result.Rows))
+	// 1000 + 2500 - 4.50 - 5000 (HOOL purchase), matching bean-query.
+	assert.Equal(t, "Assets:Checking", result.Rows[0][0].(string))
+	inv := result.Rows[0][1].(*Inventory)
+	assert.Equal(t, "-1504.5 USD", valueString(inv))
+
+	// The HOOL position keeps its cost basis, stamped with the transaction
+	// date like official booking.
+	assert.Equal(t, "Assets:Invest", result.Rows[1][0].(string))
+	assert.Equal(t, "10 HOOL {500 USD, 2014-04-01}", valueString(result.Rows[1][1].(*Inventory)))
+}
+
+func TestExecuteImplicitGroupBy(t *testing.T) {
+	result := runQuery(t, "SELECT currency, sum(number) ORDER BY currency")
+
+	assert.Equal(t, 2, len(result.Rows))
+	assert.Equal(t, "HOOL", result.Rows[0][0].(string))
+	assert.Equal(t, "USD", result.Rows[1][0].(string))
+	assert.Equal(t, "-5000", result.Rows[1][1].(decimal.Decimal).String())
+}
+
+func TestExecuteGlobalAggregate(t *testing.T) {
+	result := runQuery(t, "SELECT count(date)")
+
+	assert.Equal(t, 1, len(result.Rows))
+	assert.Equal(t, int64(8), result.Rows[0][0].(int64))
+}
+
+func TestExecuteAggregates(t *testing.T) {
+	result := runQuery(t, "SELECT min(date), max(date), first(account), last(account)")
+
+	assert.Equal(t, 1, len(result.Rows))
+	row := result.Rows[0]
+	assert.Equal(t, "2014-01-02", valueString(row[0]))
+	assert.Equal(t, "2014-04-01", valueString(row[1]))
+	assert.Equal(t, "Assets:Checking", row[2].(string))
+	assert.Equal(t, "Assets:Checking", row[3].(string))
+}
+
+func TestExecuteOrderBy(t *testing.T) {
+	result := runQuery(t, "SELECT date ORDER BY date DESC LIMIT 2")
+
+	assert.Equal(t, 2, len(result.Rows))
+	assert.Equal(t, "2014-04-01", valueString(result.Rows[0][0]))
+}
+
+func TestExecuteOrderByHiddenColumnIsStripped(t *testing.T) {
+	result := runQuery(t, "SELECT account ORDER BY date DESC LIMIT 1")
+
+	assert.Equal(t, 1, len(result.Columns))
+	assert.Equal(t, 1, len(result.Rows[0]))
+	assert.Equal(t, "Assets:Invest", result.Rows[0][0].(string))
+}
+
+func TestExecuteDistinct(t *testing.T) {
+	result := runQuery(t, "SELECT DISTINCT currency")
+	assert.Equal(t, 2, len(result.Rows))
+}
+
+func TestExecuteLimit(t *testing.T) {
+	result := runQuery(t, "SELECT date LIMIT 3")
+	assert.Equal(t, 3, len(result.Rows))
+}
+
+func TestExecuteRunningBalance(t *testing.T) {
+	result := runQuery(t, "SELECT balance WHERE account = 'Assets:Checking'")
+
+	assert.Equal(t, 4, len(result.Rows))
+	assert.Equal(t, "1000 USD", valueString(result.Rows[0][0]))
+	assert.Equal(t, "3500 USD", valueString(result.Rows[1][0]))
+	assert.Equal(t, "3495.5 USD", valueString(result.Rows[2][0]))
+	// Buying HOOL for -5000.00 USD sends the balance negative.
+	assert.Equal(t, "-1504.5 USD", valueString(result.Rows[3][0]))
+}
+
+func TestExecuteTagsAndLinks(t *testing.T) {
+	result := runQuery(t, "SELECT date WHERE 'job' in tags")
+	assert.Equal(t, 2, len(result.Rows))
+
+	result = runQuery(t, "SELECT date WHERE 'ticket' in links")
+	assert.Equal(t, 2, len(result.Rows))
+}
+
+func TestExecuteRegexMatch(t *testing.T) {
+	result := runQuery(t, "SELECT DISTINCT account WHERE account ~ 'Assets'")
+	assert.Equal(t, 2, len(result.Rows))
+}
+
+func TestExecutePriceConversion(t *testing.T) {
+	result := runQuery(t, "SELECT convert(units(position), 'USD') WHERE currency = 'HOOL'")
+
+	assert.Equal(t, 1, len(result.Rows))
+	assert.Equal(t, "5200 USD", valueString(result.Rows[0][0]))
+}
+
+func TestExecuteValueAtCost(t *testing.T) {
+	result := runQuery(t, "SELECT value(position) WHERE currency = 'HOOL'")
+
+	assert.Equal(t, 1, len(result.Rows))
+	assert.Equal(t, "5200 USD", valueString(result.Rows[0][0]))
+}
+
+func TestExecuteMetadata(t *testing.T) {
+	result := runQuery(t, "SELECT entry_meta('meta') WHERE entry_meta('meta') != NULL LIMIT 1")
+	assert.Equal(t, 1, len(result.Rows))
+	assert.Equal(t, "posting-level", result.Rows[0][0].(string))
+}
+
+func TestExecuteOpenOnSummarizes(t *testing.T) {
+	// OPEN ON replaces earlier transactions with S-flagged opening entries
+	// at the day before the open date.
+	result := runQuery(t, "SELECT date, flag, account, narration FROM OPEN ON 2014-03-01 WHERE flag = 'S' ORDER BY account")
+
+	assert.True(t, len(result.Rows) > 0)
+	assert.Equal(t, "2014-02-28", valueString(result.Rows[0][0]))
+	assert.Equal(t, "Opening balance for 'Assets:Checking' (Summarization)", result.Rows[0][3].(string))
+}
+
+func TestExecuteCancellation(t *testing.T) {
+	qctx, tree := newTestContext(t)
+	stmt, err := bql.Parse("SELECT date")
+	assert.NoError(t, err)
+	compiled, err := Compile(qctx, stmt)
+	assert.NoError(t, err)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = Execute(cancelled, qctx, tree, compiled)
+	assert.Error(t, err)
+}

--- a/query/functions.go
+++ b/query/functions.go
@@ -1,0 +1,699 @@
+package query
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/robinvdvleuten/beancount/ledger"
+	"github.com/shopspring/decimal"
+)
+
+// funcOverload is one typed signature of a simple function. TAny parameters
+// match any argument type.
+type funcOverload struct {
+	params []DType
+	result DType
+	call   func(row *Row, args []any) any
+}
+
+// funcDef is a simple function with one or more overloads, tried in order.
+type funcDef struct {
+	overloads []funcOverload
+}
+
+// matchOverload selects the first overload compatible with the argument
+// types. Arguments of unknown type (TAny) match any parameter.
+func (d *funcDef) matchOverload(argTypes []DType) *funcOverload {
+	for i := range d.overloads {
+		o := &d.overloads[i]
+		if len(o.params) != len(argTypes) {
+			continue
+		}
+		ok := true
+		for j, param := range o.params {
+			if param != TAny && argTypes[j] != TAny && param != argTypes[j] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return o
+		}
+	}
+	return nil
+}
+
+// functions is the registry of simple functions, shared by the targets and
+// filter environments, matching the official bean-query environment.
+var functions = map[string]*funcDef{
+	"abs": {overloads: []funcOverload{
+		{[]DType{TDecimal}, TDecimal, func(_ *Row, args []any) any {
+			return args[0].(decimal.Decimal).Abs()
+		}},
+		{[]DType{TInt}, TInt, func(_ *Row, args []any) any {
+			v := args[0].(int64)
+			if v < 0 {
+				return -v
+			}
+			return v
+		}},
+		{[]DType{TPosition}, TPosition, func(_ *Row, args []any) any {
+			p := args[0].(*Position)
+			return &Position{Units: Amount{Number: p.Units.Number.Abs(), Currency: p.Units.Currency}, Cost: p.Cost}
+		}},
+		{[]DType{TInventory}, TInventory, func(_ *Row, args []any) any {
+			inv := args[0].(*Inventory)
+			result := NewInventory()
+			for _, p := range inv.Positions() {
+				result.AddPosition(&Position{Units: Amount{Number: p.Units.Number.Abs(), Currency: p.Units.Currency}, Cost: p.Cost})
+			}
+			return result
+		}},
+	}},
+
+	"neg": {overloads: []funcOverload{
+		{[]DType{TDecimal}, TDecimal, func(_ *Row, args []any) any {
+			return args[0].(decimal.Decimal).Neg()
+		}},
+		{[]DType{TInt}, TInt, func(_ *Row, args []any) any {
+			return -args[0].(int64)
+		}},
+		{[]DType{TAmount}, TAmount, func(_ *Row, args []any) any {
+			a := args[0].(*Amount)
+			return &Amount{Number: a.Number.Neg(), Currency: a.Currency}
+		}},
+		{[]DType{TPosition}, TPosition, func(_ *Row, args []any) any {
+			p := args[0].(*Position)
+			return &Position{Units: Amount{Number: p.Units.Number.Neg(), Currency: p.Units.Currency}, Cost: p.Cost}
+		}},
+		{[]DType{TInventory}, TInventory, func(_ *Row, args []any) any {
+			return args[0].(*Inventory).Neg()
+		}},
+	}},
+
+	// Date functions.
+	"year": {overloads: []funcOverload{
+		{[]DType{TDate}, TInt, func(_ *Row, args []any) any {
+			return int64(args[0].(*ast.Date).Year())
+		}},
+	}},
+	"month": {overloads: []funcOverload{
+		{[]DType{TDate}, TInt, func(_ *Row, args []any) any {
+			return int64(args[0].(*ast.Date).Month())
+		}},
+	}},
+	"day": {overloads: []funcOverload{
+		{[]DType{TDate}, TInt, func(_ *Row, args []any) any {
+			return int64(args[0].(*ast.Date).Day())
+		}},
+	}},
+	"quarter": {overloads: []funcOverload{
+		{[]DType{TDate}, TString, func(_ *Row, args []any) any {
+			d := args[0].(*ast.Date)
+			return fmt.Sprintf("%04d-Q%d", d.Year(), (int(d.Month())+2)/3)
+		}},
+	}},
+	"weekday": {overloads: []funcOverload{
+		{[]DType{TDate}, TString, func(_ *Row, args []any) any {
+			return args[0].(*ast.Date).Format("Mon")
+		}},
+	}},
+	"ymonth": {overloads: []funcOverload{
+		{[]DType{TDate}, TDate, func(_ *Row, args []any) any {
+			d := args[0].(*ast.Date)
+			return &ast.Date{Time: time.Date(d.Year(), d.Month(), 1, 0, 0, 0, 0, time.UTC)}
+		}},
+	}},
+	"today": {overloads: []funcOverload{
+		{[]DType{}, TDate, func(_ *Row, _ []any) any {
+			now := time.Now()
+			return &ast.Date{Time: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)}
+		}},
+	}},
+	"date": {overloads: []funcOverload{
+		{[]DType{TInt, TInt, TInt}, TDate, func(_ *Row, args []any) any {
+			return &ast.Date{Time: time.Date(int(args[0].(int64)), time.Month(args[1].(int64)), int(args[2].(int64)), 0, 0, 0, 0, time.UTC)}
+		}},
+		{[]DType{TString}, TDate, func(_ *Row, args []any) any {
+			date := &ast.Date{}
+			if err := date.Capture([]string{args[0].(string)}); err != nil {
+				return nil
+			}
+			return date
+		}},
+	}},
+	"date_add": {overloads: []funcOverload{
+		{[]DType{TDate, TInt}, TDate, func(_ *Row, args []any) any {
+			d := args[0].(*ast.Date)
+			return &ast.Date{Time: d.AddDate(0, 0, int(args[1].(int64)))}
+		}},
+	}},
+	"date_diff": {overloads: []funcOverload{
+		{[]DType{TDate, TDate}, TInt, func(_ *Row, args []any) any {
+			a, b := args[0].(*ast.Date), args[1].(*ast.Date)
+			return int64(a.Sub(b.Time).Hours() / 24)
+		}},
+	}},
+
+	// Account functions.
+	"parent": {overloads: []funcOverload{
+		{[]DType{TString}, TString, func(_ *Row, args []any) any {
+			account := args[0].(string)
+			if idx := strings.LastIndex(account, ":"); idx >= 0 {
+				return account[:idx]
+			}
+			return ""
+		}},
+	}},
+	"leaf": {overloads: []funcOverload{
+		{[]DType{TString}, TString, func(_ *Row, args []any) any {
+			account := args[0].(string)
+			if idx := strings.LastIndex(account, ":"); idx >= 0 {
+				return account[idx+1:]
+			}
+			return account
+		}},
+	}},
+	"root": {overloads: []funcOverload{
+		{[]DType{TString, TInt}, TString, func(_ *Row, args []any) any {
+			parts := strings.Split(args[0].(string), ":")
+			n := min(int(args[1].(int64)), len(parts))
+			return strings.Join(parts[:n], ":")
+		}},
+	}},
+	"account_sortkey": {overloads: []funcOverload{
+		{[]DType{TString}, TString, func(row *Row, args []any) any {
+			return accountSortKey(row.Ctx, args[0].(string))
+		}},
+	}},
+	"open_date": {overloads: []funcOverload{
+		{[]DType{TString}, TDate, func(row *Row, args []any) any {
+			if account, ok := row.Ctx.Ledger.GetAccount(args[0].(string)); ok && account.OpenDate != nil {
+				return account.OpenDate
+			}
+			return nil
+		}},
+	}},
+	"close_date": {overloads: []funcOverload{
+		{[]DType{TString}, TDate, func(row *Row, args []any) any {
+			if account, ok := row.Ctx.Ledger.GetAccount(args[0].(string)); ok && account.CloseDate != nil {
+				return account.CloseDate
+			}
+			return nil
+		}},
+	}},
+	"has_account": {overloads: []funcOverload{
+		{[]DType{TString}, TBool, func(row *Row, args []any) any {
+			txn, ok := row.Entry.(*ast.Transaction)
+			if !ok {
+				return false
+			}
+			re, err := regexp.Compile(args[0].(string))
+			if err != nil {
+				return false
+			}
+			for _, posting := range txn.Postings {
+				if re.MatchString(string(posting.Account)) {
+					return true
+				}
+			}
+			return false
+		}},
+	}},
+
+	// Amount, position, and inventory functions.
+	"number": {overloads: []funcOverload{
+		{[]DType{TAmount}, TDecimal, func(_ *Row, args []any) any {
+			return args[0].(*Amount).Number
+		}},
+	}},
+	"currency": {overloads: []funcOverload{
+		{[]DType{TAmount}, TString, func(_ *Row, args []any) any {
+			return args[0].(*Amount).Currency
+		}},
+	}},
+	"commodity": {overloads: []funcOverload{
+		{[]DType{TAmount}, TString, func(_ *Row, args []any) any {
+			return args[0].(*Amount).Currency
+		}},
+	}},
+	"units": {overloads: []funcOverload{
+		{[]DType{TPosition}, TAmount, func(_ *Row, args []any) any {
+			p := args[0].(*Position)
+			return &Amount{Number: p.Units.Number, Currency: p.Units.Currency}
+		}},
+		{[]DType{TInventory}, TInventory, func(_ *Row, args []any) any {
+			inv := args[0].(*Inventory)
+			result := NewInventory()
+			for _, p := range inv.Positions() {
+				result.AddAmount(&Amount{Number: p.Units.Number, Currency: p.Units.Currency})
+			}
+			return result
+		}},
+	}},
+	"cost": {overloads: []funcOverload{
+		{[]DType{TPosition}, TAmount, func(_ *Row, args []any) any {
+			return positionCost(args[0].(*Position))
+		}},
+		{[]DType{TInventory}, TInventory, func(_ *Row, args []any) any {
+			inv := args[0].(*Inventory)
+			result := NewInventory()
+			for _, p := range inv.Positions() {
+				result.AddAmount(positionCost(p))
+			}
+			return result
+		}},
+	}},
+	"only": {overloads: []funcOverload{
+		{[]DType{TString, TInventory}, TAmount, func(_ *Row, args []any) any {
+			currency := args[0].(string)
+			total := decimal.Decimal{}
+			for _, p := range args[1].(*Inventory).Positions() {
+				if p.Units.Currency == currency {
+					total = total.Add(p.Units.Number)
+				}
+			}
+			return &Amount{Number: total, Currency: currency}
+		}},
+	}},
+	"filter_currency": {overloads: []funcOverload{
+		{[]DType{TPosition, TString}, TPosition, func(_ *Row, args []any) any {
+			p := args[0].(*Position)
+			if p.Units.Currency == args[1].(string) {
+				return p
+			}
+			return nil
+		}},
+		{[]DType{TInventory, TString}, TInventory, func(_ *Row, args []any) any {
+			currency := args[1].(string)
+			result := NewInventory()
+			for _, p := range args[0].(*Inventory).Positions() {
+				if p.Units.Currency == currency {
+					result.AddPosition(p)
+				}
+			}
+			return result
+		}},
+	}},
+	"getprice": {overloads: []funcOverload{
+		{[]DType{TString, TString}, TDecimal, func(row *Row, args []any) any {
+			return getPrice(row, args[0].(string), args[1].(string), nil)
+		}},
+		{[]DType{TString, TString, TDate}, TDecimal, func(row *Row, args []any) any {
+			return getPrice(row, args[0].(string), args[1].(string), args[2].(*ast.Date))
+		}},
+	}},
+	"convert": {overloads: []funcOverload{
+		{[]DType{TAmount, TString}, TAmount, func(row *Row, args []any) any {
+			return convertAmount(row, args[0].(*Amount), args[1].(string), nil)
+		}},
+		{[]DType{TAmount, TString, TDate}, TAmount, func(row *Row, args []any) any {
+			return convertAmount(row, args[0].(*Amount), args[1].(string), args[2].(*ast.Date))
+		}},
+		{[]DType{TPosition, TString}, TAmount, func(row *Row, args []any) any {
+			p := args[0].(*Position)
+			return convertAmount(row, &p.Units, args[1].(string), nil)
+		}},
+		{[]DType{TPosition, TString, TDate}, TAmount, func(row *Row, args []any) any {
+			p := args[0].(*Position)
+			return convertAmount(row, &p.Units, args[1].(string), args[2].(*ast.Date))
+		}},
+		{[]DType{TInventory, TString}, TInventory, func(row *Row, args []any) any {
+			return convertInventory(row, args[0].(*Inventory), args[1].(string), nil)
+		}},
+		{[]DType{TInventory, TString, TDate}, TInventory, func(row *Row, args []any) any {
+			return convertInventory(row, args[0].(*Inventory), args[1].(string), args[2].(*ast.Date))
+		}},
+	}},
+	"value": {overloads: []funcOverload{
+		{[]DType{TPosition}, TAmount, func(row *Row, args []any) any {
+			return positionValue(row, args[0].(*Position), nil)
+		}},
+		{[]DType{TPosition, TDate}, TAmount, func(row *Row, args []any) any {
+			return positionValue(row, args[0].(*Position), args[1].(*ast.Date))
+		}},
+		{[]DType{TInventory}, TInventory, func(row *Row, args []any) any {
+			return inventoryValue(row, args[0].(*Inventory), nil)
+		}},
+		{[]DType{TInventory, TDate}, TInventory, func(row *Row, args []any) any {
+			return inventoryValue(row, args[0].(*Inventory), args[1].(*ast.Date))
+		}},
+	}},
+	"possign": {overloads: []funcOverload{
+		{[]DType{TDecimal, TString}, TDecimal, func(row *Row, args []any) any {
+			if accountInvertsSign(row.Ctx, args[1].(string)) {
+				return args[0].(decimal.Decimal).Neg()
+			}
+			return args[0]
+		}},
+		{[]DType{TAmount, TString}, TAmount, func(row *Row, args []any) any {
+			a := args[0].(*Amount)
+			if accountInvertsSign(row.Ctx, args[1].(string)) {
+				return &Amount{Number: a.Number.Neg(), Currency: a.Currency}
+			}
+			return a
+		}},
+		{[]DType{TPosition, TString}, TPosition, func(row *Row, args []any) any {
+			p := args[0].(*Position)
+			if accountInvertsSign(row.Ctx, args[1].(string)) {
+				return &Position{Units: Amount{Number: p.Units.Number.Neg(), Currency: p.Units.Currency}, Cost: p.Cost}
+			}
+			return p
+		}},
+		{[]DType{TInventory, TString}, TInventory, func(row *Row, args []any) any {
+			if accountInvertsSign(row.Ctx, args[1].(string)) {
+				return args[0].(*Inventory).Neg()
+			}
+			return args[0]
+		}},
+	}},
+	"safediv": {overloads: []funcOverload{
+		{[]DType{TDecimal, TDecimal}, TDecimal, func(_ *Row, args []any) any {
+			return safeDiv(args[0].(decimal.Decimal), args[1].(decimal.Decimal))
+		}},
+		{[]DType{TDecimal, TInt}, TDecimal, func(_ *Row, args []any) any {
+			return safeDiv(args[0].(decimal.Decimal), decimal.NewFromInt(args[1].(int64)))
+		}},
+	}},
+
+	// String functions.
+	"str": {overloads: []funcOverload{
+		{[]DType{TAny}, TString, func(_ *Row, args []any) any {
+			return valueString(args[0])
+		}},
+	}},
+	"length": {overloads: []funcOverload{
+		{[]DType{TString}, TInt, func(_ *Row, args []any) any {
+			return int64(len(args[0].(string)))
+		}},
+		{[]DType{TSet}, TInt, func(_ *Row, args []any) any {
+			return int64(len(args[0].(Set)))
+		}},
+	}},
+	"maxwidth": {overloads: []funcOverload{
+		{[]DType{TString, TInt}, TString, func(_ *Row, args []any) any {
+			return shorten(args[0].(string), int(args[1].(int64)))
+		}},
+	}},
+	"upper": {overloads: []funcOverload{
+		{[]DType{TString}, TString, func(_ *Row, args []any) any {
+			return strings.ToUpper(args[0].(string))
+		}},
+	}},
+	"lower": {overloads: []funcOverload{
+		{[]DType{TString}, TString, func(_ *Row, args []any) any {
+			return strings.ToLower(args[0].(string))
+		}},
+	}},
+	"grep": {overloads: []funcOverload{
+		{[]DType{TString, TString}, TString, func(_ *Row, args []any) any {
+			re, err := regexp.Compile(args[0].(string))
+			if err != nil {
+				return nil
+			}
+			if match := re.FindString(args[1].(string)); match != "" {
+				return match
+			}
+			return nil
+		}},
+	}},
+	"grepn": {overloads: []funcOverload{
+		{[]DType{TString, TString, TInt}, TString, func(_ *Row, args []any) any {
+			re, err := regexp.Compile(args[0].(string))
+			if err != nil {
+				return nil
+			}
+			groups := re.FindStringSubmatch(args[1].(string))
+			n := int(args[2].(int64))
+			if groups == nil || n < 0 || n >= len(groups) {
+				return nil
+			}
+			return groups[n]
+		}},
+	}},
+	"subst": {overloads: []funcOverload{
+		{[]DType{TString, TString, TString}, TString, func(_ *Row, args []any) any {
+			re, err := regexp.Compile(args[0].(string))
+			if err != nil {
+				return nil
+			}
+			return re.ReplaceAllString(args[2].(string), args[1].(string))
+		}},
+	}},
+	"findfirst": {overloads: []funcOverload{
+		{[]DType{TString, TSet}, TString, func(_ *Row, args []any) any {
+			re, err := regexp.Compile(args[0].(string))
+			if err != nil {
+				return nil
+			}
+			for _, elem := range args[1].(Set).Sorted() {
+				if re.MatchString(elem) {
+					return elem
+				}
+			}
+			return nil
+		}},
+	}},
+	"joinstr": {overloads: []funcOverload{
+		{[]DType{TSet}, TString, func(_ *Row, args []any) any {
+			return strings.Join(args[0].(Set).Sorted(), ",")
+		}},
+	}},
+	"coalesce": {overloads: []funcOverload{
+		{[]DType{TAny, TAny}, TAny, func(_ *Row, args []any) any {
+			if args[0] != nil {
+				return args[0]
+			}
+			return args[1]
+		}},
+	}},
+
+	// Metadata functions.
+	"meta": {overloads: []funcOverload{
+		{[]DType{TString}, TAny, func(row *Row, args []any) any {
+			if row.Posting == nil {
+				return nil
+			}
+			return metaLookup(row.Posting.Metadata, args[0].(string))
+		}},
+	}},
+	"entry_meta": {overloads: []funcOverload{
+		{[]DType{TString}, TAny, func(row *Row, args []any) any {
+			if row.Txn == nil {
+				return nil
+			}
+			return metaLookup(row.Txn.Metadata, args[0].(string))
+		}},
+	}},
+	"any_meta": {overloads: []funcOverload{
+		{[]DType{TString}, TAny, func(row *Row, args []any) any {
+			key := args[0].(string)
+			if row.Posting != nil {
+				if v := metaLookup(row.Posting.Metadata, key); v != nil {
+					return v
+				}
+			}
+			if row.Txn != nil {
+				return metaLookup(row.Txn.Metadata, key)
+			}
+			return nil
+		}},
+	}},
+}
+
+// positionCost returns a position's total cost as an amount, or its units
+// when no cost basis is attached.
+func positionCost(p *Position) *Amount {
+	if p.Cost == nil {
+		return &Amount{Number: p.Units.Number, Currency: p.Units.Currency}
+	}
+	return &Amount{Number: p.Units.Number.Mul(p.Cost.Number), Currency: p.Cost.Currency}
+}
+
+// priceDate defaults a missing conversion date to today, matching the
+// official functions that value at the current date.
+func priceDate(date *ast.Date) *ast.Date {
+	if date != nil {
+		return date
+	}
+	now := time.Now()
+	return &ast.Date{Time: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)}
+}
+
+func getPrice(row *Row, from, to string, date *ast.Date) any {
+	if rate, ok := priceLookup(row.Ctx, priceDate(date), from, to); ok {
+		return rate
+	}
+	return nil
+}
+
+// convertAmount converts an amount to the given currency, returning it
+// unmodified when no conversion rate is available (official behavior).
+func convertAmount(row *Row, a *Amount, currency string, date *ast.Date) any {
+	if a.Currency == currency {
+		return a
+	}
+	if rate, ok := priceLookup(row.Ctx, priceDate(date), a.Currency, currency); ok {
+		return &Amount{Number: a.Number.Mul(rate), Currency: currency}
+	}
+	return a
+}
+
+func convertInventory(row *Row, inv *Inventory, currency string, date *ast.Date) any {
+	result := NewInventory()
+	for _, p := range inv.Positions() {
+		converted := convertAmount(row, &p.Units, currency, date).(*Amount)
+		result.AddAmount(converted)
+	}
+	return result
+}
+
+// positionValue converts a position to its cost currency at market value.
+// Positions without a cost basis are returned as their units.
+func positionValue(row *Row, p *Position, date *ast.Date) any {
+	if p.Cost == nil {
+		return &Amount{Number: p.Units.Number, Currency: p.Units.Currency}
+	}
+	return convertAmount(row, &p.Units, p.Cost.Currency, date)
+}
+
+func inventoryValue(row *Row, inv *Inventory, date *ast.Date) any {
+	result := NewInventory()
+	for _, p := range inv.Positions() {
+		result.AddAmount(positionValue(row, p, date).(*Amount))
+	}
+	return result
+}
+
+// shorten emulates Python's textwrap.shorten, which the official maxwidth
+// function uses: whitespace collapses, whole words are kept while they fit,
+// and truncation appends the "[...]" placeholder.
+func shorten(s string, width int) string {
+	words := strings.Fields(s)
+	collapsed := strings.Join(words, " ")
+	if len(collapsed) <= width {
+		return collapsed
+	}
+	const placeholder = " [...]"
+	var out string
+	for _, word := range words {
+		candidate := out
+		if candidate != "" {
+			candidate += " "
+		}
+		candidate += word
+		if len(candidate)+len(placeholder) > width {
+			break
+		}
+		out = candidate
+	}
+	if out == "" {
+		return strings.TrimSpace(placeholder)
+	}
+	return out + placeholder
+}
+
+func safeDiv(a, b decimal.Decimal) decimal.Decimal {
+	if b.IsZero() {
+		return decimal.Decimal{}
+	}
+	return a.Div(b)
+}
+
+// accountOrder is the canonical account type ordering used for sort keys and
+// sign correction.
+var accountOrder = []ast.AccountType{
+	ast.AccountTypeAssets,
+	ast.AccountTypeLiabilities,
+	ast.AccountTypeEquity,
+	ast.AccountTypeIncome,
+	ast.AccountTypeExpenses,
+}
+
+func accountType(ctx *Context, account string) (ast.AccountType, bool) {
+	root := account
+	if idx := strings.Index(account, ":"); idx >= 0 {
+		root = account[:idx]
+	}
+	if ctx != nil && ctx.Config != nil {
+		return ctx.Config.GetAccountTypeFromName(root)
+	}
+	return 0, false
+}
+
+// accountSortKey renders a sortable key placing accounts in canonical type
+// order (Assets, Liabilities, Equity, Income, Expenses).
+func accountSortKey(ctx *Context, account string) string {
+	typ, ok := accountType(ctx, account)
+	index := len(accountOrder)
+	if ok {
+		for i, t := range accountOrder {
+			if t == typ {
+				index = i
+				break
+			}
+		}
+	}
+	return fmt.Sprintf("%d-%s", index, account)
+}
+
+// accountInvertsSign reports whether an account's usual balance is negative
+// (liabilities, equity, income), for the possign function.
+func accountInvertsSign(ctx *Context, account string) bool {
+	typ, ok := accountType(ctx, account)
+	if !ok {
+		return false
+	}
+	switch typ {
+	case ast.AccountTypeLiabilities, ast.AccountTypeEquity, ast.AccountTypeIncome:
+		return true
+	}
+	return false
+}
+
+// metaLookup finds a metadata key and converts its value to a query value.
+func metaLookup(metadata []*ast.Metadata, key string) any {
+	for _, md := range metadata {
+		if md.Key == key {
+			return metaValue(md.Value)
+		}
+	}
+	return nil
+}
+
+func metaValue(v *ast.MetadataValue) any {
+	if v == nil {
+		return nil
+	}
+	switch {
+	case v.StringValue != nil:
+		return v.StringValue.String()
+	case v.Date != nil:
+		return v.Date
+	case v.Account != nil:
+		return string(*v.Account)
+	case v.Currency != nil:
+		return *v.Currency
+	case v.Tag != nil:
+		return string(*v.Tag)
+	case v.Link != nil:
+		return string(*v.Link)
+	case v.Number != nil:
+		if number, err := decimal.NewFromString(*v.Number); err == nil {
+			return number
+		}
+		return nil
+	case v.Amount != nil:
+		number, err := ledger.ParseAmount(v.Amount)
+		if err != nil {
+			return nil
+		}
+		return &Amount{Number: number, Currency: v.Amount.Currency}
+	case v.Boolean != nil:
+		return *v.Boolean
+	}
+	return nil
+}

--- a/query/render.go
+++ b/query/render.go
@@ -1,0 +1,626 @@
+package query
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/shopspring/decimal"
+)
+
+// RenderText writes a result as bean-query's default text table: headers
+// centered and truncated to the data width, a dashed rule, and per-type
+// value alignment. Empty results render as "(empty)".
+func RenderText(result *Result, w io.Writer) error {
+	if len(result.Rows) == 0 {
+		_, err := io.WriteString(w, "(empty)\n")
+		return err
+	}
+
+	renderers := prepareRenderers(result, false)
+
+	var b strings.Builder
+	for i, col := range result.Columns {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		width := renderers[i].width()
+		name := col.Name
+		if columnAllNull(result, i) {
+			// Columns with only NULL values render a blank header in the
+			// official output.
+			name = ""
+		}
+		b.WriteString(center(truncate(name, width), width))
+	}
+	b.WriteByte('\n')
+
+	for i := range result.Columns {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(strings.Repeat("-", renderers[i].width()))
+	}
+	b.WriteByte('\n')
+
+	for _, row := range result.Rows {
+		for i, value := range row {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(renderers[i].format(value))
+		}
+		b.WriteByte('\n')
+	}
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// RenderCSV writes a result as bean-query's CSV output: full column names in
+// the header, width-padded cells (an official quirk), and CRLF line endings.
+// With numberify, amount-bearing columns split into one numeric column per
+// currency.
+func RenderCSV(result *Result, w io.Writer, numberify bool) error {
+	if numberify {
+		result = numberifyResult(result)
+	}
+	renderers := prepareRenderers(result, true)
+
+	var b strings.Builder
+	header := make([]string, len(result.Columns))
+	for i, col := range result.Columns {
+		header[i] = col.Name
+	}
+	writeCSVRecord(&b, header)
+
+	record := make([]string, len(result.Columns))
+	for _, row := range result.Rows {
+		for i, value := range row {
+			record[i] = renderers[i].format(value)
+		}
+		writeCSVRecord(&b, record)
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// writeCSVRecord writes one CSV record with Python's QUOTE_MINIMAL rules:
+// fields are quoted only when they contain a separator, quote, or newline.
+// Go's encoding/csv also quotes leading spaces, which would break parity
+// with the official output's padded cells.
+func writeCSVRecord(b *strings.Builder, fields []string) {
+	for i, field := range fields {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if strings.ContainsAny(field, ",\"\r\n") {
+			b.WriteByte('"')
+			b.WriteString(strings.ReplaceAll(field, `"`, `""`))
+			b.WriteByte('"')
+		} else {
+			b.WriteString(field)
+		}
+	}
+	b.WriteString("\r\n")
+}
+
+func columnAllNull(result *Result, col int) bool {
+	for _, row := range result.Rows {
+		if row[col] != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func prepareRenderers(result *Result, forCSV bool) []columnRenderer {
+	renderers := make([]columnRenderer, len(result.Columns))
+	for i, col := range result.Columns {
+		renderers[i] = newRenderer(col.Type, forCSV)
+	}
+	for _, row := range result.Rows {
+		for i, value := range row {
+			renderers[i].prepare(value)
+		}
+	}
+	return renderers
+}
+
+// numberifyResult splits amount, position, and inventory columns into one
+// decimal column per currency, named "column (CUR)", with currencies in
+// order of first appearance.
+func numberifyResult(result *Result) *Result {
+	type split struct {
+		column     int
+		currencies []string
+		index      map[string]int
+	}
+
+	var columns []ResultColumn
+	splits := make(map[int]*split)
+	mapping := make([]int, 0, len(result.Columns)) // start index of each source column
+
+	for i, col := range result.Columns {
+		mapping = append(mapping, len(columns))
+		switch col.Type {
+		case TAmount, TPosition, TInventory:
+			s := &split{column: i, index: make(map[string]int)}
+			for _, row := range result.Rows {
+				for _, currency := range valueCurrencies(row[i]) {
+					if _, ok := s.index[currency]; !ok {
+						s.index[currency] = len(s.currencies)
+						s.currencies = append(s.currencies, currency)
+					}
+				}
+			}
+			splits[i] = s
+			for _, currency := range s.currencies {
+				columns = append(columns, ResultColumn{
+					Name: fmt.Sprintf("%s (%s)", col.Name, currency),
+					Type: TDecimal,
+				})
+			}
+			if len(s.currencies) == 0 {
+				// Keep a single empty column so the header survives.
+				columns = append(columns, ResultColumn{Name: col.Name, Type: TDecimal})
+			}
+		default:
+			columns = append(columns, col)
+		}
+	}
+
+	rows := make([][]any, len(result.Rows))
+	for r, row := range result.Rows {
+		values := make([]any, len(columns))
+		for i, value := range row {
+			if s, ok := splits[i]; ok {
+				for currency, offset := range s.index {
+					if number, ok := currencyNumber(value, currency); ok {
+						values[mapping[i]+offset] = number
+					}
+				}
+			} else {
+				values[mapping[i]] = value
+			}
+		}
+		rows[r] = values
+	}
+
+	// Quantize each currency column to its maximum scale so 1000 and 4.50
+	// render as 1000.00 and 4.50, matching the official per-currency
+	// precision.
+	for _, s := range splits {
+		for _, offset := range s.index {
+			col := mapping[s.column] + offset
+			var scale int32
+			for _, row := range rows {
+				if number, ok := row[col].(decimal.Decimal); ok {
+					scale = max(scale, -number.Exponent())
+				}
+			}
+			for _, row := range rows {
+				if number, ok := row[col].(decimal.Decimal); ok {
+					row[col] = number.Round(scale)
+				}
+			}
+		}
+	}
+	return &Result{Columns: columns, Rows: rows}
+}
+
+// valueCurrencies lists the currencies present in an amount-bearing value.
+func valueCurrencies(v any) []string {
+	switch val := v.(type) {
+	case *Amount:
+		return []string{val.Currency}
+	case *Position:
+		return []string{val.Units.Currency}
+	case *Inventory:
+		var currencies []string
+		seen := make(map[string]bool)
+		for _, p := range val.Positions() {
+			if !seen[p.Units.Currency] {
+				seen[p.Units.Currency] = true
+				currencies = append(currencies, p.Units.Currency)
+			}
+		}
+		return currencies
+	}
+	return nil
+}
+
+// currencyNumber extracts the units number of one currency from an
+// amount-bearing value, summing inventory lots.
+func currencyNumber(v any, currency string) (decimal.Decimal, bool) {
+	switch val := v.(type) {
+	case *Amount:
+		if val.Currency == currency {
+			return val.Number, true
+		}
+	case *Position:
+		if val.Units.Currency == currency {
+			return val.Units.Number, true
+		}
+	case *Inventory:
+		total := decimal.Decimal{}
+		found := false
+		for _, p := range val.Positions() {
+			if p.Units.Currency == currency {
+				total = total.Add(p.Units.Number)
+				found = true
+			}
+		}
+		if found {
+			return total, true
+		}
+	}
+	return decimal.Decimal{}, false
+}
+
+// columnRenderer accumulates layout information over a column's values in
+// prepare, then formats each value padded to the column width.
+type columnRenderer interface {
+	prepare(v any)
+	width() int
+	format(v any) string
+}
+
+func newRenderer(t DType, forCSV bool) columnRenderer {
+	switch t {
+	case TAny:
+		// Object-typed columns are width-padded in text but written raw in
+		// CSV, matching the official renderer.
+		return &stringRenderer{unpadded: forCSV}
+	case TDate:
+		return &dateRenderer{}
+	case TInt:
+		return &intRenderer{}
+	case TBool:
+		return &boolRenderer{}
+	case TDecimal:
+		return &decimalRenderer{}
+	case TAmount:
+		return &amountRenderer{numbers: newNumberField()}
+	case TPosition, TInventory:
+		return &positionRenderer{numbers: newNumberField()}
+	default:
+		return &stringRenderer{}
+	}
+}
+
+func truncate(s string, width int) string {
+	if len(s) > width {
+		return s[:width]
+	}
+	return s
+}
+
+// center pads s to width with the extra space on the right, like Python's
+// str.center used by the official renderer.
+func center(s string, width int) string {
+	total := width - len(s)
+	if total <= 0 {
+		return s
+	}
+	left := total / 2
+	return strings.Repeat(" ", left) + s + strings.Repeat(" ", total-left)
+}
+
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+func padLeft(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-len(s)) + s
+}
+
+// stringRenderer renders strings, sets, and polymorphic values left-aligned.
+type stringRenderer struct {
+	w        int
+	unpadded bool
+}
+
+func (r *stringRenderer) toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if set, ok := v.(Set); ok {
+		return strings.Join(set.Sorted(), ",")
+	}
+	return valueString(v)
+}
+
+func (r *stringRenderer) prepare(v any) {
+	if n := len(r.toString(v)); n > r.w {
+		r.w = n
+	}
+}
+
+func (r *stringRenderer) width() int { return max(r.w, 1) }
+
+func (r *stringRenderer) format(v any) string {
+	if r.unpadded {
+		return r.toString(v)
+	}
+	return padRight(r.toString(v), r.width())
+}
+
+type dateRenderer struct{}
+
+func (r *dateRenderer) prepare(any) {}
+func (r *dateRenderer) width() int  { return 10 }
+
+func (r *dateRenderer) format(v any) string {
+	if date, ok := v.(*ast.Date); ok && date != nil {
+		return date.String()
+	}
+	return strings.Repeat(" ", 10)
+}
+
+type intRenderer struct {
+	w int
+}
+
+func (r *intRenderer) prepare(v any) {
+	if n, ok := v.(int64); ok {
+		if width := len(fmt.Sprintf("%d", n)); width > r.w {
+			r.w = width
+		}
+	}
+}
+
+func (r *intRenderer) width() int { return max(r.w, 1) }
+
+func (r *intRenderer) format(v any) string {
+	if n, ok := v.(int64); ok {
+		return padLeft(fmt.Sprintf("%d", n), r.width())
+	}
+	return strings.Repeat(" ", r.width())
+}
+
+// boolRenderer renders TRUE/FALSE with the official fixed width of 5.
+type boolRenderer struct{}
+
+func (r *boolRenderer) prepare(any) {}
+func (r *boolRenderer) width() int  { return 5 }
+
+func (r *boolRenderer) format(v any) string {
+	b, ok := v.(bool)
+	if !ok {
+		return strings.Repeat(" ", 5)
+	}
+	if b {
+		return padRight("TRUE", 5)
+	}
+	return "FALSE"
+}
+
+// decimalRenderer aligns numbers at the decimal point, preserving each
+// value's own digits (space-padded, not zero-padded).
+type decimalRenderer struct {
+	intW  int
+	fracW int
+}
+
+func decimalParts(d decimal.Decimal) (string, string) {
+	scale := max(-d.Exponent(), 0)
+	s := d.StringFixed(scale)
+	if idx := strings.IndexByte(s, '.'); idx >= 0 {
+		return s[:idx], s[idx+1:]
+	}
+	return s, ""
+}
+
+func (r *decimalRenderer) prepare(v any) {
+	d, ok := v.(decimal.Decimal)
+	if !ok {
+		return
+	}
+	intPart, fracPart := decimalParts(d)
+	r.intW = max(r.intW, len(intPart))
+	r.fracW = max(r.fracW, len(fracPart))
+}
+
+func (r *decimalRenderer) width() int {
+	w := r.intW
+	if r.fracW > 0 {
+		w += 1 + r.fracW
+	}
+	return max(w, 1)
+}
+
+func (r *decimalRenderer) format(v any) string {
+	d, ok := v.(decimal.Decimal)
+	if !ok {
+		return strings.Repeat(" ", r.width())
+	}
+	intPart, fracPart := decimalParts(d)
+	s := padLeft(intPart, r.intW)
+	if r.fracW > 0 {
+		if fracPart != "" {
+			s += "." + fracPart
+		}
+		s = padRight(s, r.width())
+	}
+	return s
+}
+
+// numberField aligns amount numbers at the decimal point with per-currency
+// precision: each currency's numbers are quantized to the maximum scale seen
+// for that currency, and the fraction field is space-padded to the widest
+// currency's scale.
+type numberField struct {
+	intW     int
+	fracW    int // widest fraction incl. the dot
+	currFrac map[string]int
+}
+
+func newNumberField() *numberField {
+	return &numberField{currFrac: make(map[string]int)}
+}
+
+func (f *numberField) observe(number decimal.Decimal, currency string) {
+	scale := int(max(-number.Exponent(), 0))
+	f.currFrac[currency] = max(f.currFrac[currency], scale)
+	intPart, _ := decimalParts(number)
+	f.intW = max(f.intW, len(intPart))
+}
+
+// finish computes the fraction field width after all values are observed.
+func (f *numberField) finish() {
+	for _, scale := range f.currFrac {
+		if scale > 0 {
+			f.fracW = max(f.fracW, 1+scale)
+		}
+	}
+}
+
+func (f *numberField) width() int { return f.intW + f.fracW }
+
+func (f *numberField) format(number decimal.Decimal, currency string) string {
+	scale := f.currFrac[currency]
+	s := number.StringFixed(int32(scale))
+	var intPart, fracPart string
+	if idx := strings.IndexByte(s, '.'); idx >= 0 {
+		intPart, fracPart = s[:idx], s[idx+1:]
+	} else {
+		intPart = s
+	}
+	out := padLeft(intPart, f.intW)
+	if fracPart != "" {
+		out += "." + fracPart
+	}
+	return padRight(out, f.width())
+}
+
+// amountRenderer renders "number CURRENCY" with the number field aligned.
+type amountRenderer struct {
+	numbers  *numberField
+	curW     int
+	prepared bool
+}
+
+func (r *amountRenderer) prepare(v any) {
+	if a, ok := v.(*Amount); ok && a != nil {
+		r.numbers.observe(a.Number, a.Currency)
+		r.curW = max(r.curW, len(a.Currency))
+	}
+}
+
+func (r *amountRenderer) width() int {
+	if !r.prepared {
+		r.numbers.finish()
+		r.prepared = true
+	}
+	if r.curW == 0 {
+		return 1
+	}
+	return r.numbers.width() + 1 + r.curW
+}
+
+func (r *amountRenderer) format(v any) string {
+	width := r.width()
+	a, ok := v.(*Amount)
+	if !ok || a == nil {
+		return strings.Repeat(" ", width)
+	}
+	return padRight(r.numbers.format(a.Number, a.Currency)+" "+a.Currency, width)
+}
+
+// positionRenderer renders positions and inventories: each position is a
+// fixed-width sub-cell (aligned number, padded currency, optional cost) and
+// inventories join their positions with ", ".
+type positionRenderer struct {
+	numbers  *numberField
+	curW     int
+	costW    int
+	cellW    int
+	prepared bool
+}
+
+func (r *positionRenderer) positions(v any) []*Position {
+	switch val := v.(type) {
+	case *Position:
+		if val != nil {
+			return []*Position{val}
+		}
+	case *Inventory:
+		if val != nil {
+			return val.Positions()
+		}
+	}
+	return nil
+}
+
+// costString renders a cost basis for position cells. The official renderer
+// omits the booking-stamped cost date, showing only number, currency, and
+// label.
+func costString(c *Cost) string {
+	var b strings.Builder
+	b.WriteByte('{')
+	b.WriteString(c.Number.StringFixed(max(-c.Number.Exponent(), 0)))
+	b.WriteByte(' ')
+	b.WriteString(c.Currency)
+	if c.Label != "" {
+		fmt.Fprintf(&b, ", %q", c.Label)
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func (r *positionRenderer) prepare(v any) {
+	for _, p := range r.positions(v) {
+		r.numbers.observe(p.Units.Number, p.Units.Currency)
+		r.curW = max(r.curW, len(p.Units.Currency))
+		if p.Cost != nil {
+			r.costW = max(r.costW, len(costString(p.Cost)))
+		}
+	}
+}
+
+// subWidth is the fixed width of one rendered position.
+func (r *positionRenderer) subWidth() int {
+	w := r.numbers.width() + 1 + r.curW
+	if r.costW > 0 {
+		w += 1 + r.costW
+	}
+	return w
+}
+
+func (r *positionRenderer) width() int {
+	if !r.prepared {
+		r.numbers.finish()
+		r.prepared = true
+		r.cellW = max(r.subWidth(), 1)
+	}
+	return r.cellW
+}
+
+func (r *positionRenderer) formatPosition(p *Position) string {
+	s := r.numbers.format(p.Units.Number, p.Units.Currency) + " " + padRight(p.Units.Currency, r.curW)
+	if p.Cost != nil {
+		s += " " + costString(p.Cost)
+	}
+	return padRight(s, r.subWidth())
+}
+
+func (r *positionRenderer) format(v any) string {
+	width := r.width()
+	positions := r.positions(v)
+	if len(positions) == 0 {
+		return strings.Repeat(" ", width)
+	}
+	parts := make([]string, len(positions))
+	for i, p := range positions {
+		parts[i] = r.formatPosition(p)
+	}
+	return padRight(strings.Join(parts, ", "), width)
+}

--- a/query/render_test.go
+++ b/query/render_test.go
@@ -1,0 +1,126 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+// The expected outputs in this file are byte-for-byte copies of bean-query
+// 2.3.6 output for the same ledger and queries. Line numbers matter (the
+// lineno column), so this fixture must not be reformatted.
+const renderLedger = `option "title" "Query Reference"
+option "operating_currency" "USD"
+
+2014-01-01 open Assets:Checking USD
+2014-01-01 open Assets:Invest HOOL
+2014-01-01 open Income:Salary USD
+2014-01-01 open Expenses:Food USD
+2014-01-01 open Equity:Opening-Balances USD
+
+2014-01-02 * "Opening"
+  Assets:Checking  1000.00 USD
+  Equity:Opening-Balances
+
+2014-02-03 * "Acme" "Salary" #job ^ticket
+  Assets:Checking  2500.00 USD
+  Income:Salary
+
+2014-03-05 * "Cafe" "Coffee" #food
+  Expenses:Food  4.50 USD
+  Assets:Checking
+
+2014-04-01 * "Broker" "Buy HOOL"
+  Assets:Invest  10 HOOL {500.00 USD}
+  Assets:Checking
+
+2014-05-01 price HOOL 520.00 USD
+`
+
+func renderText(t *testing.T, query string) string {
+	t.Helper()
+	ctx, tree := newContextFromSource(t, renderLedger)
+	var b strings.Builder
+	assert.NoError(t, RenderText(runQueryOn(t, ctx, tree, query), &b))
+	return b.String()
+}
+
+func renderCSV(t *testing.T, query string, numberify bool) string {
+	t.Helper()
+	ctx, tree := newContextFromSource(t, renderLedger)
+	var b strings.Builder
+	assert.NoError(t, RenderCSV(runQueryOn(t, ctx, tree, query), &b, numberify))
+	return b.String()
+}
+
+func TestRenderTextGroupedInventory(t *testing.T) {
+	expected := "" +
+		"        account                sum_position       \n" +
+		"----------------------- --------------------------\n" +
+		"Assets:Checking         -1504.50 USD              \n" +
+		"Equity:Opening-Balances -1000.00 USD              \n" +
+		"Income:Salary           -2500.00 USD              \n" +
+		"Expenses:Food               4.50 USD              \n" +
+		"Assets:Invest              10    HOOL {500.00 USD}\n"
+	assert.Equal(t, expected, renderText(t, "select account, sum(position) group by account"))
+}
+
+func TestRenderTextInventoryJoinsPositions(t *testing.T) {
+	// A multi-position inventory joins fixed-width sub-cells with ", " and
+	// overflows the column, matching the official renderer.
+	expected := "" +
+		"       sum_position       \n" +
+		"--------------------------\n" +
+		"   10    HOOL {500.00 USD}, -5000.00 USD              \n"
+	assert.Equal(t, expected, renderText(t, "select sum(position)"))
+}
+
+func TestRenderTextHeaderTruncation(t *testing.T) {
+	expected := "" +
+		"tag li    date   \n" +
+		"--- -- ----------\n" +
+		"    10 2014-01-02\n" +
+		"    10 2014-01-02\n" +
+		"job 14 2014-02-03\n"
+	assert.Equal(t, expected, renderText(t, "select tags, lineno, date limit 3"))
+}
+
+func TestRenderTextScalarTypes(t *testing.T) {
+	expected := "" +
+		"equal c3_ c4\n" +
+		"----- --- --\n" +
+		"TRUE  3.5 42\n"
+	assert.Equal(t, expected, renderText(t, "select 2 = 2, 3.5, 42 limit 1"))
+}
+
+func TestRenderTextEmpty(t *testing.T) {
+	assert.Equal(t, "(empty)\n", renderText(t, "select account where account = 'NOPE'"))
+}
+
+func TestRenderCSVPadsValues(t *testing.T) {
+	expected := "account\r\n" +
+		"Assets:Checking        \r\n" +
+		"Equity:Opening-Balances\r\n"
+	assert.Equal(t, expected, renderCSV(t, "select account limit 2", false))
+}
+
+func TestRenderCSVGroupedInventory(t *testing.T) {
+	expected := "account,sum_position\r\n" +
+		"Assets:Checking        ,-1504.50 USD              \r\n" +
+		"Assets:Invest          ,   10    HOOL {500.00 USD}\r\n" +
+		"Equity:Opening-Balances,-1000.00 USD              \r\n" +
+		"Expenses:Food          ,    4.50 USD              \r\n" +
+		"Income:Salary          ,-2500.00 USD              \r\n"
+	assert.Equal(t, expected, renderCSV(t, "select account, sum(position) group by account order by account", false))
+}
+
+func TestRenderCSVNumberify(t *testing.T) {
+	expected := "account,sum_position (USD),sum_position (HOOL)\r\n" +
+		"Assets:Checking        ,-1504.50,  \r\n" +
+		"Assets:Invest          ,        ,10\r\n" +
+		"Equity:Opening-Balances,-1000.00,  \r\n" +
+		"Expenses:Food          ,    4.50,  \r\n" +
+		"Income:Salary          ,-2500.00,  \r\n"
+	assert.Equal(t, expected, renderCSV(t, "select account, sum(position) group by account order by account", true))
+}

--- a/query/summarize.go
+++ b/query/summarize.go
@@ -1,0 +1,219 @@
+package query
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/shopspring/decimal"
+)
+
+// applyFromTransforms applies the FROM clause's summarization transforms to
+// the directive stream, in grammar order: OPEN ON, CLOSE [ON], CLEAR. The
+// FROM filter expression runs after the transforms (official behavior).
+// A bare CLOSE truncates nothing here: its conversion entries only exist for
+// multi-currency conversion tracking, which the official tool also skips for
+// ledgers without a conversion imbalance.
+func applyFromTransforms(qctx *Context, entries []ast.Directive, from *CompiledFrom) []ast.Directive {
+	if from.OpenOn != nil {
+		entries = openTransform(qctx, entries, from.OpenOn)
+	}
+	if from.CloseOn != nil {
+		entries = closeTransform(entries, from.CloseOn)
+	}
+	if from.Clear {
+		entries = clearTransform(qctx, entries)
+	}
+	return entries
+}
+
+// openTransform summarizes all transactions before the open date: income and
+// expenses balances collapse into Equity:Earnings:Previous, and every
+// balance-sheet account's inventory becomes an S-flagged opening transaction
+// at the day before the open date, posted against Equity:Opening-Balances.
+func openTransform(qctx *Context, entries []ast.Directive, openDate *ast.Date) []ast.Directive {
+	var kept []ast.Directive
+	accounts := make(map[string]*Inventory)
+
+	for _, entry := range entries {
+		txn, isTxn := entry.(*ast.Transaction)
+		if entry.Date().Before(openDate.Time) {
+			if !isTxn {
+				kept = append(kept, entry)
+				continue
+			}
+			bookTransaction(accounts, txn)
+			continue
+		}
+		kept = append(kept, entry)
+	}
+
+	// Collapse income and expenses into the previous-earnings account.
+	earnings := equityAccount(qctx, "Earnings:Previous")
+	for account, inventory := range accounts {
+		if typ, ok := accountType(qctx, account); ok &&
+			(typ == ast.AccountTypeIncome || typ == ast.AccountTypeExpenses) {
+			target, ok := accounts[earnings]
+			if !ok {
+				target = NewInventory()
+				accounts[earnings] = target
+			}
+			target.AddInventory(inventory)
+			delete(accounts, account)
+		}
+	}
+
+	openingDate := &ast.Date{Time: openDate.AddDate(0, 0, -1)}
+	opening := equityAccount(qctx, "Opening-Balances")
+	var txns []ast.Directive
+	for _, account := range sortedAccounts(accounts) {
+		inventory := accounts[account]
+		if inventory.IsEmpty() {
+			continue
+		}
+		narration := fmt.Sprintf("Opening balance for '%s' (Summarization)", account)
+		txns = append(txns, balanceTransaction(openingDate, narration, "S", account, opening, inventory, false))
+	}
+
+	result := make([]ast.Directive, 0, len(txns)+len(kept))
+	result = append(result, txns...)
+	result = append(result, kept...)
+	return result
+}
+
+// closeTransform truncates the stream at the close date, keeping entries
+// strictly before it.
+func closeTransform(entries []ast.Directive, closeDate *ast.Date) []ast.Directive {
+	var kept []ast.Directive
+	for _, entry := range entries {
+		if entry.Date().Before(closeDate.Time) {
+			kept = append(kept, entry)
+		}
+	}
+	return kept
+}
+
+// clearTransform appends T-flagged transactions at the last entry date that
+// transfer every income and expenses balance to Equity:Earnings:Current.
+func clearTransform(qctx *Context, entries []ast.Directive) []ast.Directive {
+	if len(entries) == 0 {
+		return entries
+	}
+
+	accounts := make(map[string]*Inventory)
+	var lastDate time.Time
+	for _, entry := range entries {
+		if entry.Date().After(lastDate) {
+			lastDate = entry.Date().Time
+		}
+		if txn, ok := entry.(*ast.Transaction); ok {
+			bookTransaction(accounts, txn)
+		}
+	}
+
+	earnings := equityAccount(qctx, "Earnings:Current")
+	transferDate := &ast.Date{Time: lastDate}
+	result := entries
+	for _, account := range sortedAccounts(accounts) {
+		typ, ok := accountType(qctx, account)
+		if !ok || (typ != ast.AccountTypeIncome && typ != ast.AccountTypeExpenses) {
+			continue
+		}
+		inventory := accounts[account]
+		if inventory.IsEmpty() {
+			continue
+		}
+		narration := fmt.Sprintf("Transfer balance for '%s' (Transfer balance)", account)
+		result = append(result, balanceTransaction(transferDate, narration, "T", account, earnings, inventory, true))
+	}
+	return result
+}
+
+// bookTransaction books a transaction's postings into the per-account
+// inventories with the same lot-date semantics as row generation.
+func bookTransaction(accounts map[string]*Inventory, txn *ast.Transaction) {
+	for _, posting := range txn.Postings {
+		inventory, ok := accounts[string(posting.Account)]
+		if !ok {
+			inventory = NewInventory()
+			accounts[string(posting.Account)] = inventory
+		}
+		position := postingPosition(posting, txn.Date())
+		if position == nil {
+			continue
+		}
+		if position.Cost != nil && (posting.Cost == nil || posting.Cost.Date == nil) {
+			if inherited := inventory.matchLotDate(position); inherited != nil {
+				position.Cost.Date = inherited
+			}
+		}
+		inventory.AddPosition(position)
+	}
+}
+
+// balanceTransaction builds a synthetic two-legged transaction moving an
+// account's inventory to (or from) an equity account. When negate is set the
+// account leg carries the negated balance (transfers); otherwise the account
+// leg restates the balance (opening balances). The equity legs are the cost
+// value of the opposite side, one posting per currency.
+func balanceTransaction(date *ast.Date, narration, flag, account, equity string, inventory *Inventory, negate bool) *ast.Transaction {
+	var postings []*ast.Posting
+	equityTotals := make(map[string]decimal.Decimal)
+	var equityOrder []string
+
+	for _, p := range inventory.Positions() {
+		units := p.Units.Number
+		if negate {
+			units = units.Neg()
+		}
+		opts := []ast.PostingOption{ast.WithAmount(numberString(units), p.Units.Currency)}
+		if p.Cost != nil {
+			cost := ast.NewCostWithDate(
+				ast.NewAmount(numberString(p.Cost.Number), p.Cost.Currency), p.Cost.Date)
+			cost.Label = p.Cost.Label
+			opts = append(opts, ast.WithCost(cost))
+		}
+		postings = append(postings, ast.NewPosting(ast.Account(account), opts...))
+
+		value := positionCost(p)
+		number := value.Number
+		if !negate {
+			number = number.Neg()
+		}
+		if _, ok := equityTotals[value.Currency]; !ok {
+			equityOrder = append(equityOrder, value.Currency)
+		}
+		equityTotals[value.Currency] = equityTotals[value.Currency].Add(number)
+	}
+
+	for _, currency := range equityOrder {
+		postings = append(postings, ast.NewPosting(ast.Account(equity),
+			ast.WithAmount(numberString(equityTotals[currency]), currency)))
+	}
+
+	return ast.NewTransaction(date, narration, ast.WithFlag(flag), ast.WithPostings(postings...))
+}
+
+func sortedAccounts(accounts map[string]*Inventory) []string {
+	names := make([]string, 0, len(accounts))
+	for name := range accounts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// equityAccount joins the configured equity root with a sub-account name.
+func equityAccount(qctx *Context, sub string) string {
+	root := "Equity"
+	if qctx != nil && qctx.Config != nil && qctx.Config.AccountNames != nil {
+		root = qctx.Config.AccountNames.Equity
+	}
+	return root + ":" + sub
+}
+
+// numberString renders a decimal preserving its scale.
+func numberString(d decimal.Decimal) string {
+	return d.StringFixed(max(-d.Exponent(), 0))
+}

--- a/query/types.go
+++ b/query/types.go
@@ -1,0 +1,396 @@
+// Package query implements the Beancount Query Language (BQL) engine: it
+// compiles statements parsed by the bql package against a processed ledger
+// and executes them into result tables. The pipeline mirrors the official
+// bean-query tool: parse (bql package) → compile → execute → render.
+package query
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/robinvdvleuten/beancount/ast"
+	"github.com/shopspring/decimal"
+)
+
+// DType identifies the static type of a compiled expression. It drives
+// function overload resolution at compile time and column formatting in the
+// renderers. Runtime values are Go values: bool, int64, decimal.Decimal,
+// string, *ast.Date, Set, *Amount, *Position, and *Inventory; NULL is nil.
+type DType uint8
+
+const (
+	TAny DType = iota // unknown or polymorphic (renders via str)
+	TBool
+	TInt
+	TDecimal
+	TString
+	TDate
+	TSet
+	TAmount
+	TPosition
+	TInventory
+)
+
+var dtypeNames = map[DType]string{
+	TAny:       "object",
+	TBool:      "bool",
+	TInt:       "int",
+	TDecimal:   "Decimal",
+	TString:    "str",
+	TDate:      "date",
+	TSet:       "set",
+	TAmount:    "Amount",
+	TPosition:  "Position",
+	TInventory: "Inventory",
+}
+
+func (t DType) String() string {
+	if name, ok := dtypeNames[t]; ok {
+		return name
+	}
+	return "object"
+}
+
+// Amount is a number with a currency, the query-engine counterpart of a
+// beancount amount.
+type Amount struct {
+	Number   decimal.Decimal
+	Currency string
+}
+
+// Cost is the per-unit cost basis attached to a position.
+type Cost struct {
+	Number   decimal.Decimal
+	Currency string
+	Date     *ast.Date
+	Label    string
+}
+
+// Position is an amount of units held at an optional cost.
+type Position struct {
+	Units Amount
+	Cost  *Cost
+}
+
+// costKey returns a stable identity for grouping positions by (currency, cost).
+func (p *Position) costKey() string {
+	if p.Cost == nil {
+		return p.Units.Currency
+	}
+	return fmt.Sprintf("%s|%s|%s|%s|%s",
+		p.Units.Currency, p.Cost.Currency, p.Cost.Number.String(), p.Cost.Date.String(), p.Cost.Label)
+}
+
+// Inventory is a collection of positions keyed by currency and cost basis.
+// Summing amounts or positions in aggregate functions produces an Inventory.
+type Inventory struct {
+	positions map[string]*Position
+}
+
+// NewInventory creates an empty inventory.
+func NewInventory() *Inventory {
+	return &Inventory{positions: make(map[string]*Position)}
+}
+
+// AddAmount adds a cost-less amount to the inventory.
+func (inv *Inventory) AddAmount(a *Amount) {
+	inv.AddPosition(&Position{Units: *a})
+}
+
+// AddPosition merges a position into the inventory, summing units for
+// positions with the same currency and cost basis. Positions that sum to
+// zero are removed, matching official inventories.
+func (inv *Inventory) AddPosition(p *Position) {
+	key := p.costKey()
+	if existing, ok := inv.positions[key]; ok {
+		existing.Units.Number = existing.Units.Number.Add(p.Units.Number)
+		if existing.Units.Number.IsZero() {
+			delete(inv.positions, key)
+		}
+		return
+	}
+	if p.Units.Number.IsZero() {
+		return
+	}
+	inv.positions[key] = &Position{Units: p.Units, Cost: p.Cost}
+}
+
+// AddInventory merges another inventory into this one.
+func (inv *Inventory) AddInventory(other *Inventory) {
+	for _, p := range other.positions {
+		inv.AddPosition(p)
+	}
+}
+
+// IsEmpty reports whether the inventory has no non-zero positions.
+func (inv *Inventory) IsEmpty() bool {
+	for _, p := range inv.positions {
+		if !p.Units.Number.IsZero() {
+			return false
+		}
+	}
+	return true
+}
+
+// Positions returns the inventory positions in a stable order: by units
+// currency, then cost currency, number, date, and label.
+func (inv *Inventory) Positions() []*Position {
+	positions := make([]*Position, 0, len(inv.positions))
+	for _, p := range inv.positions {
+		positions = append(positions, p)
+	}
+	sort.Slice(positions, func(i, j int) bool {
+		a, b := positions[i], positions[j]
+		if a.Units.Currency != b.Units.Currency {
+			return a.Units.Currency < b.Units.Currency
+		}
+		ac, bc := a.Cost, b.Cost
+		switch {
+		case ac == nil && bc == nil:
+			return false
+		case ac == nil:
+			return true
+		case bc == nil:
+			return false
+		}
+		if ac.Currency != bc.Currency {
+			return ac.Currency < bc.Currency
+		}
+		if !ac.Number.Equal(bc.Number) {
+			return ac.Number.LessThan(bc.Number)
+		}
+		return ac.Date.String() < bc.Date.String()
+	})
+	return positions
+}
+
+// Copy returns a deep copy of the inventory.
+func (inv *Inventory) Copy() *Inventory {
+	copied := NewInventory()
+	for key, p := range inv.positions {
+		copied.positions[key] = &Position{Units: p.Units, Cost: p.Cost}
+	}
+	return copied
+}
+
+// matchLotDate returns the cost date of an existing lot that a reduction
+// matches by currency and cost basis, or nil. Used to inherit lot dates the
+// way official booking does.
+func (inv *Inventory) matchLotDate(p *Position) *ast.Date {
+	if p.Cost == nil {
+		return nil
+	}
+	var best *ast.Date
+	for _, lot := range inv.positions {
+		if lot.Cost == nil || lot.Cost.Date == nil {
+			continue
+		}
+		if lot.Units.Currency != p.Units.Currency ||
+			lot.Cost.Currency != p.Cost.Currency ||
+			!lot.Cost.Number.Equal(p.Cost.Number) {
+			continue
+		}
+		if lot.Units.Number.Sign() == 0 || lot.Units.Number.Sign() == p.Units.Number.Sign() {
+			continue
+		}
+		if best == nil || lot.Cost.Date.Before(best.Time) {
+			best = lot.Cost.Date
+		}
+	}
+	return best
+}
+
+// Neg returns a new inventory with all unit numbers negated.
+func (inv *Inventory) Neg() *Inventory {
+	negated := NewInventory()
+	for key, p := range inv.positions {
+		negated.positions[key] = &Position{
+			Units: Amount{Number: p.Units.Number.Neg(), Currency: p.Units.Currency},
+			Cost:  p.Cost,
+		}
+	}
+	return negated
+}
+
+// Set is an unordered collection of strings, used for tags, links, and
+// other-accounts values.
+type Set map[string]struct{}
+
+// NewSet builds a Set from the given elements.
+func NewSet(elems ...string) Set {
+	set := make(Set, len(elems))
+	for _, elem := range elems {
+		set[elem] = struct{}{}
+	}
+	return set
+}
+
+// Contains reports whether the set contains the given element.
+func (s Set) Contains(elem string) bool {
+	_, ok := s[elem]
+	return ok
+}
+
+// Sorted returns the set elements in lexicographic order.
+func (s Set) Sorted() []string {
+	elems := make([]string, 0, len(s))
+	for elem := range s {
+		elems = append(elems, elem)
+	}
+	sort.Strings(elems)
+	return elems
+}
+
+// truthy converts a value to a boolean following Python truthiness, which is
+// what the official implementation applies in logical contexts: NULL, zero,
+// empty strings and empty collections are false.
+func truthy(v any) bool {
+	switch val := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return val
+	case int64:
+		return val != 0
+	case decimal.Decimal:
+		return !val.IsZero()
+	case string:
+		return val != ""
+	case *ast.Date:
+		return !val.IsZero()
+	case Set:
+		return len(val) > 0
+	case *Amount:
+		return val != nil
+	case *Position:
+		return val != nil
+	case *Inventory:
+		return val != nil && len(val.positions) > 0
+	default:
+		return v != nil
+	}
+}
+
+// asDecimal coerces numeric values (int64, decimal) to a decimal.
+func asDecimal(v any) (decimal.Decimal, bool) {
+	switch val := v.(type) {
+	case int64:
+		return decimal.NewFromInt(val), true
+	case decimal.Decimal:
+		return val, true
+	}
+	return decimal.Decimal{}, false
+}
+
+// compareValues orders two values of compatible types, returning -1, 0, or 1.
+// NULL sorts before everything. Values of incompatible types compare by their
+// string forms as a last resort, so sorting never fails at runtime.
+func compareValues(l, r any) int {
+	if l == nil && r == nil {
+		return 0
+	}
+	if l == nil {
+		return -1
+	}
+	if r == nil {
+		return 1
+	}
+
+	if ld, ok := asDecimal(l); ok {
+		if rd, ok := asDecimal(r); ok {
+			return ld.Cmp(rd)
+		}
+	}
+
+	switch lv := l.(type) {
+	case string:
+		if rv, ok := r.(string); ok {
+			return strings.Compare(lv, rv)
+		}
+	case *ast.Date:
+		if rv, ok := r.(*ast.Date); ok {
+			switch {
+			case lv.Before(rv.Time):
+				return -1
+			case lv.After(rv.Time):
+				return 1
+			default:
+				return 0
+			}
+		}
+	case bool:
+		if rv, ok := r.(bool); ok {
+			switch {
+			case !lv && rv:
+				return -1
+			case lv && !rv:
+				return 1
+			default:
+				return 0
+			}
+		}
+	}
+
+	return strings.Compare(valueString(l), valueString(r))
+}
+
+// valueString renders a value the way the official str() function does,
+// following Python conventions for booleans and sets.
+func valueString(v any) string {
+	switch val := v.(type) {
+	case nil:
+		return ""
+	case bool:
+		if val {
+			return "True"
+		}
+		return "False"
+	case string:
+		return val
+	case int64:
+		return fmt.Sprintf("%d", val)
+	case decimal.Decimal:
+		return val.String()
+	case *ast.Date:
+		return val.String()
+	case Set:
+		if len(val) == 0 {
+			return "frozenset()"
+		}
+		elems := val.Sorted()
+		quoted := make([]string, len(elems))
+		for i, elem := range elems {
+			quoted[i] = fmt.Sprintf("'%s'", elem)
+		}
+		return "frozenset({" + strings.Join(quoted, ", ") + "})"
+	case *Amount:
+		return fmt.Sprintf("%s %s", val.Number.String(), val.Currency)
+	case *Position:
+		return positionString(val)
+	case *Inventory:
+		positions := val.Positions()
+		parts := make([]string, len(positions))
+		for i, p := range positions {
+			parts[i] = positionString(p)
+		}
+		return strings.Join(parts, ", ")
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func positionString(p *Position) string {
+	units := fmt.Sprintf("%s %s", p.Units.Number.String(), p.Units.Currency)
+	if p.Cost == nil {
+		return units
+	}
+	cost := fmt.Sprintf("%s %s", p.Cost.Number.String(), p.Cost.Currency)
+	if p.Cost.Date != nil {
+		cost += ", " + p.Cost.Date.String()
+	}
+	if p.Cost.Label != "" {
+		cost += fmt.Sprintf(", \"%s\"", p.Cost.Label)
+	}
+	return fmt.Sprintf("%s {%s}", units, cost)
+}

--- a/testdata/compliance/KNOWN_GAPS.md
+++ b/testdata/compliance/KNOWN_GAPS.md
@@ -8,8 +8,14 @@ them. Closing a gap means making the fixture pass and renaming it to drop the
 
 ## Open gaps (fixture-backed)
 
-None. Every `.pass`/`.fail` fixture in this directory agrees with
+None among the `.pass`/`.fail` check fixtures. Every one agrees with
 `bean-check` 2.3.x; the differential suite enforces it.
+
+For BQL, `query/gap_print_*.bql` diverge from `bean-query` in whitespace
+only: PRINT renders through our formatter, whose canonical layout differs
+from the official printer (per-entry number alignment, 2-space metadata
+indent). The content is equivalent beancount text that round-trips through
+`bean-check`.
 
 ## Empirically pinned option behavior
 
@@ -24,6 +30,17 @@ None. Every `.pass`/`.fail` fixture in this directory agrees with
   reports). The `account_rounding_inert` / `account_rounding_no_posting`
   fixtures prove both implementations leave the rounding account empty.
 
+- **BQL / bean-query** is implemented (`beancount query`) and pinned
+  byte-for-byte against `bean-query` 2.3.6 by the fixtures in `query/`
+  (text and csv, including numberify, shortcut statements, FROM
+  summarization, and error output). Notable pinned quirks we reproduce:
+  data-width columns with truncated centered headers, padded CSV cells
+  with Python QUOTE_MINIMAL and CRLF, per-currency decimal precision,
+  constant names sanitized by collapsing invalid runs ('USD' → `c_`),
+  implicit GROUP BY, a single trailing ORDER BY direction, `ERROR:` lines
+  on stdout with exit status 0, and `The PIVOT BY clause is not supported
+  yet.` (a v2 limitation we mirror).
+
 ## Deliberate deviations
 
 - **AVERAGE booking**: official v2 *rejects* AVERAGE at reduction time
@@ -35,7 +52,16 @@ None. Every `.pass`/`.fail` fixture in this directory agrees with
 
 ## Declared non-goals
 
-- **BQL / bean-query**: not implemented.
 - **Plugin execution**: `plugin` directives are parsed but never run
   (official v2 ships 28 plugins; `auto_accounts` and `implicit_prices`
   change check outcomes for ledgers that rely on them).
+- **BQL `id` column digests**: ids are unique and stable but hash the
+  source location, not the directive contents like `compare.hash_entry`,
+  so the hex digests differ from official output.
+- **BQL shell extras**: `EXPLAIN`, `RUN` of stored `query` directives, and
+  shell settings (`set format ...`) are not implemented; nor are the
+  beanquery v3 extensions (`HAVING`, subqueries, `CREATE TABLE`, per-term
+  ORDER BY directions).
+- **BQL dict-typed metadata functions**: `commodity_meta`, `currency_meta`,
+  `open_meta`, and `getitem` (dict-typed values) are not implemented;
+  `meta`, `entry_meta`, and `any_meta` cover scalar metadata lookups.

--- a/testdata/compliance/query/aggregates.bql
+++ b/testdata/compliance/query/aggregates.bql
@@ -1,0 +1,1 @@
+SELECT count(date), min(date), max(date), first(account), last(account)

--- a/testdata/compliance/query/balance_cross_account.bql
+++ b/testdata/compliance/query/balance_cross_account.bql
@@ -1,0 +1,1 @@
+SELECT account, balance WHERE number < 0 ORDER BY date LIMIT 6

--- a/testdata/compliance/query/balances.bql
+++ b/testdata/compliance/query/balances.bql
@@ -1,0 +1,1 @@
+BALANCES

--- a/testdata/compliance/query/balances_at_cost.bql
+++ b/testdata/compliance/query/balances_at_cost.bql
@@ -1,0 +1,1 @@
+BALANCES AT cost

--- a/testdata/compliance/query/convert_at_date.bql
+++ b/testdata/compliance/query/convert_at_date.bql
@@ -1,0 +1,1 @@
+SELECT convert(units(position), 'USD', 2023-12-31) WHERE currency = 'HOOL' ORDER BY date

--- a/testdata/compliance/query/cost_columns.bql
+++ b/testdata/compliance/query/cost_columns.bql
@@ -1,0 +1,1 @@
+SELECT date, cost_number, cost_currency, cost_date WHERE currency = 'HOOL' ORDER BY date

--- a/testdata/compliance/query/distinct.bql
+++ b/testdata/compliance/query/distinct.bql
@@ -1,0 +1,1 @@
+SELECT DISTINCT currency ORDER BY currency

--- a/testdata/compliance/query/err_bad_column.bql
+++ b/testdata/compliance/query/err_bad_column.bql
@@ -1,0 +1,1 @@
+SELECT bogus

--- a/testdata/compliance/query/err_bad_function.bql
+++ b/testdata/compliance/query/err_bad_function.bql
@@ -1,0 +1,1 @@
+SELECT bogusfn(date)

--- a/testdata/compliance/query/err_group_coverage.bql
+++ b/testdata/compliance/query/err_group_coverage.bql
@@ -1,0 +1,1 @@
+SELECT date GROUP BY narration

--- a/testdata/compliance/query/err_pivot.bql
+++ b/testdata/compliance/query/err_pivot.bql
@@ -1,0 +1,1 @@
+SELECT date, account, sum(position) GROUP BY 1, 2 PIVOT BY date, account

--- a/testdata/compliance/query/flags.bql
+++ b/testdata/compliance/query/flags.bql
@@ -1,0 +1,1 @@
+SELECT flag, count(date) GROUP BY flag ORDER BY flag

--- a/testdata/compliance/query/from_clear.bql
+++ b/testdata/compliance/query/from_clear.bql
@@ -1,0 +1,1 @@
+SELECT date, flag, narration, account, position FROM CLEAR WHERE flag = 'T' ORDER BY account

--- a/testdata/compliance/query/from_close_on.bql
+++ b/testdata/compliance/query/from_close_on.bql
@@ -1,0 +1,1 @@
+SELECT date, account, number FROM CLOSE ON 2023-06-01 ORDER BY date, account

--- a/testdata/compliance/query/from_has_account.bql
+++ b/testdata/compliance/query/from_has_account.bql
@@ -1,0 +1,1 @@
+SELECT date, narration FROM has_account('Invest')

--- a/testdata/compliance/query/from_open_close_clear.bql
+++ b/testdata/compliance/query/from_open_close_clear.bql
@@ -1,0 +1,1 @@
+SELECT account, sum(position) FROM OPEN ON 2023-06-01 CLOSE ON 2024-03-01 CLEAR GROUP BY account ORDER BY account

--- a/testdata/compliance/query/from_open_on.bql
+++ b/testdata/compliance/query/from_open_on.bql
@@ -1,0 +1,1 @@
+SELECT date, flag, payee, narration, account, position FROM OPEN ON 2024-01-01 ORDER BY date, account

--- a/testdata/compliance/query/from_year.bql
+++ b/testdata/compliance/query/from_year.bql
@@ -1,0 +1,1 @@
+SELECT count(date) FROM year = 2023

--- a/testdata/compliance/query/functions_account.bql
+++ b/testdata/compliance/query/functions_account.bql
@@ -1,0 +1,1 @@
+SELECT DISTINCT parent(account), leaf(account), root(account, 1) ORDER BY 1, 2

--- a/testdata/compliance/query/functions_amounts.bql
+++ b/testdata/compliance/query/functions_amounts.bql
@@ -1,0 +1,1 @@
+SELECT units(position), cost(position), weight, number, currency WHERE currency = 'HOOL'

--- a/testdata/compliance/query/functions_dates.bql
+++ b/testdata/compliance/query/functions_dates.bql
@@ -1,0 +1,1 @@
+SELECT DISTINCT year(date), month(date), quarter(date), weekday(date) ORDER BY 1, 2 LIMIT 8

--- a/testdata/compliance/query/functions_strings.bql
+++ b/testdata/compliance/query/functions_strings.bql
@@ -1,0 +1,1 @@
+SELECT upper(narration), lower(payee), length(account), maxwidth(narration, 6) LIMIT 5

--- a/testdata/compliance/query/gap_print_prices.bql
+++ b/testdata/compliance/query/gap_print_prices.bql
@@ -1,0 +1,1 @@
+PRINT FROM type = 'price'

--- a/testdata/compliance/query/gap_print_transactions.bql
+++ b/testdata/compliance/query/gap_print_transactions.bql
@@ -1,0 +1,1 @@
+PRINT FROM year = 2024 AND type = 'transaction'

--- a/testdata/compliance/query/group_by_index.bql
+++ b/testdata/compliance/query/group_by_index.bql
@@ -1,0 +1,1 @@
+SELECT year(date) AS year, sum(number) GROUP BY 1 ORDER BY 1

--- a/testdata/compliance/query/journal_account.bql
+++ b/testdata/compliance/query/journal_account.bql
@@ -1,0 +1,1 @@
+JOURNAL "Cash"

--- a/testdata/compliance/query/journal_all.bql
+++ b/testdata/compliance/query/journal_all.bql
@@ -1,0 +1,1 @@
+JOURNAL

--- a/testdata/compliance/query/journal_at_cost.bql
+++ b/testdata/compliance/query/journal_at_cost.bql
@@ -1,0 +1,1 @@
+JOURNAL "Cash" AT cost

--- a/testdata/compliance/query/ledger.beancount
+++ b/testdata/compliance/query/ledger.beancount
@@ -1,0 +1,68 @@
+option "title" "Query Compliance Ledger"
+option "operating_currency" "USD"
+
+2022-12-28 open Assets:Cash USD
+2022-12-28 open Assets:Bank:Checking USD
+2022-12-28 open Assets:Invest:HOOL HOOL
+2022-12-28 open Assets:Invest:Cash USD
+2022-12-28 open Liabilities:CreditCard USD
+2022-12-28 open Income:Acme:Salary USD
+2022-12-28 open Income:Gains USD
+2022-12-28 open Expenses:Food:Coffee USD
+2022-12-28 open Expenses:Food:Restaurant USD
+2022-12-28 open Expenses:Travel USD
+2022-12-28 open Equity:Opening-Balances USD
+
+2023-01-01 * "Opening balances"
+  Assets:Cash  200.00 USD
+  Assets:Bank:Checking  3000.00 USD
+  Equity:Opening-Balances
+
+2023-01-15 * "Acme" "January salary" #salary
+  Assets:Bank:Checking  2500.00 USD
+  Income:Acme:Salary
+
+2023-02-01 * "Blue Bottle" "Morning coffee" #coffee
+  category: "drinks"
+  Expenses:Food:Coffee  4.50 USD
+  Assets:Cash
+
+2023-02-14 * "Chez Panisse" "Valentine dinner" #restaurant ^date-night
+  Expenses:Food:Restaurant  120.00 USD
+  Liabilities:CreditCard
+
+2023-03-10 * "Broker" "Buy HOOL"
+  Assets:Invest:HOOL  8 HOOL {520.00 USD}
+  Assets:Invest:Cash  -4160.00 USD
+
+2023-03-15 balance Assets:Cash  195.50 USD
+
+2023-04-02 ! "Airline" "Flight to Berlin" #trip ^bl-2023
+  Expenses:Travel  450.00 USD
+  Liabilities:CreditCard
+
+2023-05-20 * "Broker" "Sell some HOOL"
+  Assets:Invest:HOOL  -3 HOOL {520.00 USD} @ 610.00 USD
+  Assets:Invest:Cash  1830.00 USD
+  Income:Gains  -270.00 USD
+
+2023-06-01 price HOOL 640.00 USD
+
+2023-07-04 * "Cafe" "Espresso" #coffee
+  Expenses:Food:Coffee  3.75 USD
+  Assets:Cash
+
+2024-01-15 * "Acme" "January salary" #salary
+  Assets:Bank:Checking  2600.00 USD
+  Income:Acme:Salary
+
+2024-02-11 * "Blue Bottle" "Coffee beans" #coffee
+  category: "groceries"
+  Expenses:Food:Coffee  18.00 USD
+  Assets:Cash
+
+2024-03-01 close Expenses:Travel
+
+2024-04-01 event "location" "Berlin"
+
+2024-05-01 note Assets:Cash "Counted the drawer"

--- a/testdata/compliance/query/metadata.bql
+++ b/testdata/compliance/query/metadata.bql
@@ -1,0 +1,1 @@
+SELECT date, any_meta('category') AS category WHERE any_meta('category') != NULL

--- a/testdata/compliance/query/numberify_positions.bql
+++ b/testdata/compliance/query/numberify_positions.bql
@@ -1,0 +1,1 @@
+SELECT account, sum(position) GROUP BY account ORDER BY account

--- a/testdata/compliance/query/order_by_desc.bql
+++ b/testdata/compliance/query/order_by_desc.bql
@@ -1,0 +1,1 @@
+SELECT date, account ORDER BY date, account DESC LIMIT 6

--- a/testdata/compliance/query/projection_alias.bql
+++ b/testdata/compliance/query/projection_alias.bql
@@ -1,0 +1,1 @@
+SELECT date, account AS acc, narration LIMIT 8

--- a/testdata/compliance/query/running_balance.bql
+++ b/testdata/compliance/query/running_balance.bql
@@ -1,0 +1,1 @@
+SELECT date, narration, balance WHERE account = 'Assets:Cash'

--- a/testdata/compliance/query/select_star.bql
+++ b/testdata/compliance/query/select_star.bql
@@ -1,0 +1,1 @@
+SELECT * LIMIT 5

--- a/testdata/compliance/query/sum_number_by_currency.bql
+++ b/testdata/compliance/query/sum_number_by_currency.bql
@@ -1,0 +1,1 @@
+SELECT currency, sum(number) GROUP BY currency ORDER BY currency

--- a/testdata/compliance/query/sum_position_by_account.bql
+++ b/testdata/compliance/query/sum_position_by_account.bql
@@ -1,0 +1,1 @@
+SELECT account, sum(position) GROUP BY account ORDER BY account

--- a/testdata/compliance/query/where_comparisons.bql
+++ b/testdata/compliance/query/where_comparisons.bql
@@ -1,0 +1,1 @@
+SELECT date, account, number WHERE number >= 100 AND number < 3000 AND account ~ 'Assets' ORDER BY date, account

--- a/testdata/compliance/query/where_tags_links.bql
+++ b/testdata/compliance/query/where_tags_links.bql
@@ -1,0 +1,1 @@
+SELECT date, narration WHERE 'coffee' in tags OR 'bl-2023' in links ORDER BY date


### PR DESCRIPTION
Adds the Beancount Query Language end to end:

- query/bql: hand-rolled lexer and recursive-descent parser (zero-copy tokens, positioned errors, fuzz test), covering SELECT with all clauses, BALANCES, JOURNAL, PRINT, and the full expression grammar.
- query: value model (Amount, Position, Inventory, Set), column and function registries matching the official environments, compiler with bean-query error-message parity, executor (implicit grouping, single-direction ORDER BY, cross-account running balance, booking lot-date inheritance), FROM summarization (OPEN ON / CLOSE ON / CLEAR synthesizing the official S/T transactions), and text/CSV renderers reproducing the official layout byte for byte (truncated centered headers, per-currency decimal precision, padded CSV cells with CRLF and QUOTE_MINIMAL, numberify).
- cli: beancount query [-f text|csv] [-o FILE] [-m] FILE [QUERY], with an interactive shell on a terminal and single-query stdin mode; query errors print as ERROR: lines on stdout with exit status 0, matching the official tool.
- fix(ledger): interpolated amounts keep their decimal scale (decimal.String trims trailing zeros, so -4.50 displayed as -4.5).
- test(compliance): 38 differential fixtures in testdata/compliance/query run through both implementations whenever bean-query 2.x is on PATH, comparing stdout byte for byte in text and csv; KNOWN_GAPS.md documents the remaining divergences (print whitespace, location-based id digests, v3-only extensions).

All behavior pinned empirically against bean-query 2.3.6.